### PR TITLE
swap(mvp-rough): very rough swap mvp that loops over an order until filled

### DIFF
--- a/contracts/interfaces/enigma/IEnigmaDataStructures.sol
+++ b/contracts/interfaces/enigma/IEnigmaDataStructures.sol
@@ -77,9 +77,10 @@ interface IEnigmaDataStructures {
      * @notice Information of a tick at a tickIndex.
      */
     struct HyperSlot {
-        uint256 liquidityDelta;
+        int256 liquidityDelta;
         uint256 totalLiquidity;
         uint256 externalFeeGrowth;
         bool instantiated;
+        uint256 timestamp;
     }
 }


### PR DESCRIPTION
Fixes #46

Extremely rough swap mvp.

- Loops over an order until its filled or limit price is reached.
- Uses liquidity of each tick, and updates the next tick with the liquidity change.
- Tracks a total input/output which is used to increase/decrease global balances.

To do:
- Update adding/removing liquidity to have the their "change in liquidity" when that tick is entered/exited.
- Fees are not being taken on swap.
- Priority fee system not implemented.