### PR TITLE
Echidna/more swap invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,6 @@ lcov.info
 
 # echidna
 crytic-export/
+corpus/
 
 


### PR DESCRIPTION
# Changes
- Adds four individual invariant tests to EchidnaE2E.sol
  - Swap asset in decreases price
  - Swap quote in increases price
  - Swap asset in increases asset reserve
  - Swap quote in increases quote reserve
- Adds a check swap invariants function to check the basic invariants
  - Price changes after swap.
  - Liquidity does not change after a swap.
  - Fee growth always increases or stays the same for both the purchased and sold tokens.
  - Reserves change in appropriate direction for buy/sell swaps
- Misc: adds corpus/ to gitignore.

## Todo
- Add marginal price invariants (once math is confirmed)
- Add better time based invariants


## Ideal Test Scenario
Ideal swap invariants will simulate a single arbitrageur which generates fees for the pool. The fees are re-invested into the pool until the invariant is positive (this is a to-be implemented change in Hyper). Pool swaps should always pass as expected using arguments from the output of `getAmountOut`. Swaps with small time deltas remaining should also behave the same as swaps with longer time deltas.