### PR TITLE
fix(#174,#194): removes curve parameters from changePoolParameters

### DIFF
--- a/contracts/Hyper.sol
+++ b/contracts/Hyper.sol
@@ -687,29 +687,18 @@ contract Hyper is IHyper {
         emit CreatePool(poolId, hasController, pool.pair.tokenAsset, pool.pair.tokenQuote, price);
     }
 
-    function changeParameters(
-        uint64 poolId,
-        uint16 priorityFee,
-        uint16 fee,
-        uint16 volatility,
-        uint16 duration,
-        uint16 jit,
-        uint128 maxPrice
-    ) external lock interactions {
+    function changeParameters(uint64 poolId, uint16 priorityFee, uint16 fee, uint16 jit) external lock interactions {
         HyperPool storage pool = pools[poolId];
         if (pool.controller != msg.sender) revert NotController();
 
         HyperCurve memory modified = pool.params;
         if (jit != 0) modified.jit = jit;
-        if (maxPrice != 0) modified.maxPrice = maxPrice;
         if (fee != 0) modified.fee = fee;
-        if (volatility != 0) modified.volatility = volatility;
-        if (duration != 0) modified.duration = duration;
         if (priorityFee != 0) modified.priorityFee = priorityFee;
 
         pool.changePoolParameters(modified);
 
-        emit ChangeParameters(poolId, priorityFee, fee, volatility, duration, jit, maxPrice);
+        emit ChangeParameters(poolId, priorityFee, fee, jit);
     }
 
     /** @dev Overridable in tests.  */

--- a/contracts/interfaces/IHyper.sol
+++ b/contracts/interfaces/IHyper.sol
@@ -35,15 +35,8 @@ interface IHyperEvents {
         uint256 deltaLiquidity
     );
 
-    event ChangeParameters(
-        uint64 indexed poolId,
-        uint16 indexed priorityFee,
-        uint16 indexed fee,
-        uint16 volatility,
-        uint16 duration,
-        uint16 jit,
-        uint128 maxPrice
-    );
+    /** @dev Emits a `0` for unchanged parameters. */
+    event ChangeParameters(uint64 indexed poolId, uint16 indexed priorityFee, uint16 indexed fee, uint16 jit);
     event Collect(
         uint64 poolId,
         address account,
@@ -158,15 +151,7 @@ interface IHyperActions {
 
     function deposit() external payable;
 
-    function changeParameters(
-        uint64 poolId,
-        uint16 priorityFee,
-        uint16 fee,
-        uint16 volatility,
-        uint16 duration,
-        uint16 jit,
-        uint128 maxPrice
-    ) external;
+    function changeParameters(uint64 poolId, uint16 priorityFee, uint16 fee, uint16 jit) external;
 }
 
 interface IHyper is IHyperActions, IHyperEvents, IHyperGetters {}


### PR DESCRIPTION
# Description
- Closes #174 by removing the ability to change curve parameters, which affect the price and reserves of pools.
- Closes #194 by removing the ability to change curve parameters.