### PR TITLE
fix(#137): changes priorityFeeGrowth to invariantGrowth, removes from…

### DIFF
--- a/contracts/interfaces/IHyper.sol
+++ b/contracts/interfaces/IHyper.sol
@@ -92,7 +92,7 @@ interface IHyperGetters {
             uint128 liquidity,
             uint32 lastTimestamp,
             address controller,
-            uint256 feeGrowthGlobalReward,
+            uint256 invariantGrowthGlobal,
             uint256 feeGrowthGlobalAsset,
             uint256 feeGrowthGlobalQuote,
             HyperCurve memory,
@@ -108,12 +108,12 @@ interface IHyperGetters {
         returns (
             uint128 freeLiquidity,
             uint256 lastTimestamp,
-            uint256 feeGrowthRewardLast,
+            uint256 invariantGrowthLast,
             uint256 feeGrowthAssetLast,
             uint256 feeGrowthQuoteLast,
             uint128 tokensOwedAsset,
             uint128 tokensOwedQuote,
-            uint128 tokensOwedReward
+            uint128 invariantOwed
         );
 
     function getPairNonce() external view returns (uint24);

--- a/test/foundry/TestHyperClaim.t.sol
+++ b/test/foundry/TestHyperClaim.t.sol
@@ -105,7 +105,7 @@ contract TestHyperClaim is TestHyperSetup {
         HyperPosition memory pos = _getPosition(hs(), address(this), scenario.poolId);
         HyperPool memory pool = _getPool(hs(), scenario.poolId);
         uint tokensOwed = Assembly
-            .computeCheckpointDistance(pool.feeGrowthGlobalReward, pos.feeGrowthRewardLast)
+            .computeCheckpointDistance(pool.invariantGrowthGlobal, pos.invariantGrowthLast)
             .mulWadDown(pool.liquidity);
 
         __hyperTestingContract__.claim(scenario.poolId, 0, 0);

--- a/test/foundry/setup/TestHyperSetup.sol
+++ b/test/foundry/setup/TestHyperSetup.sol
@@ -170,6 +170,8 @@ contract TestHyperSetup is HelperHyperActions, HelperHyperInvariants, HelperHype
             "18-18 decimal pair"
         );
         scenarios.push(_scenario_18_18);
+
+        createControlledPool();
     }
 
     uint64 public constant FIRST_POOL = 0x0000010000000001;


### PR DESCRIPTION
… claim

# Description
- Closes #137 by removing the WETH accrual of "priorityFeeGrowth" rewards from `swap` and `claim`.
- Updates `feePriorityGrowth` to `invariantGrowth`, updating all respective names.
- Adds an argument and return variable to `HyperLib.syncPositionFees` to sync the invariantGrowth exactly like the fee buckets.
- Adds a conditional piece of logic to `_swap` to increase the invariantGrowth if the pool controller called the swap, and the change in the invariant was greater than zero. The actual check is not greater than, it's not equal to zero. This is because it's a cheaper check, and also because a decreasing invariant will be reverted by the previous logic.
- Adds an invariant growth swap test to HyperTestSwap.