### PR TITLE
chore: run `forge fmt` to fix code style

### DIFF
--- a/contracts/libraries/FVMLib.sol
+++ b/contracts/libraries/FVMLib.sol
@@ -189,19 +189,7 @@ function encodeCreatePool(
     (uint8 power1, uint128 base1) = AssemblyLib.fromAmount(price);
 
     data = abi.encodePacked(
-        CREATE_POOL,
-        pairId,
-        controller,
-        priorityFee,
-        fee,
-        vol,
-        dur,
-        jit,
-        uint8(52),
-        power0,
-        base0,
-        power1,
-        base1
+        CREATE_POOL, pairId, controller, priorityFee, fee, vol, dur, jit, uint8(52), power0, base0, power1, base1
     );
 }
 
@@ -248,7 +236,6 @@ function decodeAllocate(bytes calldata data) pure returns (uint8 useMax, uint64 
     poolId = uint64(bytes8(data[1:9]));
     deltaLiquidity = AssemblyLib.toAmount(data[9:]);
 }
-
 
 function encodeDeallocate(uint8 useMax, uint64 poolId, uint128 deltaLiquidity) pure returns (bytes memory data) {
     (uint8 power, uint128 base) = AssemblyLib.fromAmount(deltaLiquidity);

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -237,9 +237,7 @@ contract Setup is Test {
 
     modifier swapSome(uint128 amt, bool sellAsset) {
         uint128 amtOut = subject().getAmountOut(ghost().poolId, sellAsset, amt).safeCastTo128();
-        subject().multiprocess(
-            FVM.encodeSwap(uint8(0), ghost().poolId, amt, amtOut, uint8(sellAsset ? 1 : 0))
-        );
+        subject().multiprocess(FVM.encodeSwap(uint8(0), ghost().poolId, amt, amtOut, uint8(sellAsset ? 1 : 0)));
         _;
     }
 
@@ -249,9 +247,7 @@ contract Setup is Test {
             ? amtOut + uint256(amtOutDelta).safeCastTo128()
             : amtOut - uint256(-amtOutDelta).safeCastTo128();
 
-        subject().multiprocess(
-            FVM.encodeSwap(uint8(0), ghost().poolId, amt, amtOut, uint8(sellAsset ? 1 : 0))
-        );
+        subject().multiprocess(FVM.encodeSwap(uint8(0), ghost().poolId, amt, amtOut, uint8(sellAsset ? 1 : 0)));
         _;
     }
 

--- a/test/TestFVMLib.t.sol
+++ b/test/TestFVMLib.t.sol
@@ -30,7 +30,11 @@ contract FVMLibTarget is Test {
         return decodeClaim(data);
     }
 
-    function decodePoolId_(bytes calldata data) external pure returns (uint64 poolId, uint24 pairId, uint8 isMutable, uint32 poolNonce) {
+    function decodePoolId_(bytes calldata data)
+        external
+        pure
+        returns (uint64 poolId, uint24 pairId, uint8 isMutable, uint32 poolNonce)
+    {
         return decodePoolId(data);
     }
 
@@ -62,11 +66,19 @@ contract FVMLibTarget is Test {
         pool.price = price;
     }
 
-    function decodeAllocate_(bytes calldata data) external pure returns (uint8 useMax, uint64 poolId, uint128 deltaLiquidity) {
+    function decodeAllocate_(bytes calldata data)
+        external
+        pure
+        returns (uint8 useMax, uint64 poolId, uint128 deltaLiquidity)
+    {
         return decodeAllocate(data);
     }
 
-    function decodeDeallocate_(bytes calldata data) external pure returns (uint8 useMax, uint64 poolId, uint128 deltaLiquidity) {
+    function decodeDeallocate_(bytes calldata data)
+        external
+        pure
+        returns (uint8 useMax, uint64 poolId, uint128 deltaLiquidity)
+    {
         return decodeDeallocate(data);
     }
 }
@@ -74,20 +86,9 @@ contract FVMLibTarget is Test {
 contract TestFVMLib is Test {
     FVMLibTarget public target = new FVMLibTarget();
 
-    function testFuzz_encodeSwap(
-        bool useMax,
-        uint64 poolId,
-        uint128 amount0,
-        uint128 amount1,
-        bool sellAsset
-    ) public {
-        bytes memory data = encodeSwap(
-            useMax ? uint8(1) : uint8(0),
-            poolId,
-            amount0,
-            amount1,
-            sellAsset ? uint8(1) : uint8(0)
-        );
+    function testFuzz_encodeSwap(bool useMax, uint64 poolId, uint128 amount0, uint128 amount1, bool sellAsset) public {
+        bytes memory data =
+            encodeSwap(useMax ? uint8(1) : uint8(0), poolId, amount0, amount1, sellAsset ? uint8(1) : uint8(0));
 
         console.logBytes(data);
 
@@ -103,13 +104,7 @@ contract TestFVMLib is Test {
     function test_decodeSwap() public {
         bytes memory data = hex"0500042a0709081204";
 
-        (
-            uint8 useMax,
-            uint64 poolId,
-            uint128 input,
-            uint128 output,
-            uint8 sellAsset
-        ) = target.decodeSwap_(data);
+        (uint8 useMax, uint64 poolId, uint128 input, uint128 output, uint8 sellAsset) = target.decodeSwap_(data);
 
         assertEq(useMax, 0);
         assertEq(poolId, 42);
@@ -161,17 +156,7 @@ contract TestFVMLib is Test {
         uint128 maxPrice,
         uint128 price
     ) public {
-        bytes memory data = encodeCreatePool(
-            pairId,
-            controller,
-            priorityFee,
-            fee,
-            vol,
-            dur,
-            jit,
-            maxPrice,
-            price
-        );
+        bytes memory data = encodeCreatePool(pairId, controller, priorityFee, fee, vol, dur, jit, maxPrice, price);
 
         DecodedCreatePool memory pool = target.decodeCreatePool_(data);
 
@@ -186,16 +171,8 @@ contract TestFVMLib is Test {
         assertEq(price, pool.price);
     }
 
-    function testFuzz_encodeAllocate(
-        bool useMax,
-        uint64 poolId,
-        uint128 deltaLiquidity
-    ) public {
-        bytes memory data = encodeAllocate(
-            useMax ? uint8(1) : uint8(0),
-            poolId,
-            deltaLiquidity
-        );
+    function testFuzz_encodeAllocate(bool useMax, uint64 poolId, uint128 deltaLiquidity) public {
+        bytes memory data = encodeAllocate(useMax ? uint8(1) : uint8(0), poolId, deltaLiquidity);
 
         (uint8 useMax_, uint64 poolId_, uint128 deltaLiquidity_) = target.decodeAllocate_(data);
 
@@ -204,16 +181,8 @@ contract TestFVMLib is Test {
         assertEq(deltaLiquidity, deltaLiquidity_);
     }
 
-    function testFuzz_encodeDeallocate(
-        bool useMax,
-        uint64 poolId,
-        uint128 deltaLiquidity
-    ) public {
-        bytes memory data = encodeDeallocate(
-            useMax ? uint8(1) : uint8(0),
-            poolId,
-            deltaLiquidity
-        );
+    function testFuzz_encodeDeallocate(bool useMax, uint64 poolId, uint128 deltaLiquidity) public {
+        bytes memory data = encodeDeallocate(useMax ? uint8(1) : uint8(0), poolId, deltaLiquidity);
 
         (uint8 useMax_, uint64 poolId_, uint128 deltaLiquidity_) = target.decodeDeallocate_(data);
 
@@ -237,6 +206,4 @@ contract TestFVMLib is Test {
         assertEq(poolNonce, poolNonce_);
     }
     */
-
-
 }

--- a/test/TestPortfolioSwap.t.sol
+++ b/test/TestPortfolioSwap.t.sol
@@ -18,9 +18,7 @@ contract TestPortfolioSwap is Setup {
         uint128 amtOut = uint128(subject().getAmountOut(ghost().poolId, sellAsset, amtIn));
 
         uint256 prev = ghost().balance(address(this), ghost().quote().to_addr());
-        subject().multiprocess(
-            FVMLib.encodeSwap(uint8(0), ghost().poolId, amtIn, amtOut, uint8(sellAsset ? 1 : 0))
-        );
+        subject().multiprocess(FVMLib.encodeSwap(uint8(0), ghost().poolId, amtIn, amtOut, uint8(sellAsset ? 1 : 0)));
         uint256 post = ghost().balance(address(this), ghost().quote().to_addr());
 
         assertTrue(post > prev, "balance-did-not-increase");


### PR DESCRIPTION
Sorry, looks like prettier ran automatically in [this commit](https://github.com/primitivefinance/portfolio/pull/259/commits/ae4848b42602124aae080306bc475293759ec6c9). I've run `forge fmt` to undo this and match the style guide listed in the readme.