### PR TITLE
feat: reduce bytecode by removing unnecessary return values

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -718,8 +718,7 @@ abstract contract PortfolioVirtual is Objective {
             priorityFee: hasController ? priorityFee : 0,
             createdAt: timestamp
         });
-        params.validateParameters();
-        pool.params = params;
+        pool.changePoolParameters(params);
 
         (uint256 x, uint256 y) = computeReservesFromPrice(poolId, price);
         (pool.virtualY, pool.virtualX) = (y.safeCastTo128(), x.safeCastTo128());

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -189,9 +189,9 @@ function changePoolParameters(
     PortfolioPool storage self,
     PortfolioCurve memory updated
 ) {
-    (bool success, ) = updated.validateParameters();
+    // Reverts on invalid parameters.
+    updated.validateParameters();
     self.params = updated;
-    assert(success);
 }
 
 function changePositionLiquidity(
@@ -391,15 +391,13 @@ function maturity(
 
 function validateParameters(
     PortfolioCurve memory self
-) pure returns (bool, bytes memory) {
+) pure {
     (bool success, bytes memory reason) = self.checkParameters();
     if (!success) {
         assembly {
             revert(add(32, reason), mload(reason))
         }
     }
-
-    return (success, reason);
 }
 
 /**


### PR DESCRIPTION
`validateParameters` never returns a non-empty `reason` as it will always revert if an error has occurred. It will also only return in the case where `success == true`. We then don't need to spend the bytecode associated with returning `(true, "")` as these return values aren't used.

This removes ~0.09kB of bytecode (giving us plenty of space for #260).

I also noticed that `changePoolParameters` seems to not be being inlined properly by the compiler. Considering how small the function is you could inline it manually (as you do in `_createPool`) however I've removed this inlining for consistency as it's a relatively small change in bytecode size. 