### PR TITLE
refactor(pool-nonce): updates pool nonce to be a mapping from pair nonce

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -40,9 +40,8 @@ abstract contract PortfolioVirtual is Objective {
     address public immutable WETH;
     /// @inheritdoc IPortfolioGetters
     uint24 public getPairNonce;
-    /// @inheritdoc IPortfolioGetters
-    uint32 public getPoolNonce;
 
+    mapping(uint24 => uint32) public getPoolNonce;
     mapping(uint24 => PortfolioPair) public pairs;
     mapping(uint64 => PortfolioPool) public pools;
     mapping(address => mapping(address => uint24)) public getPairId;
@@ -631,7 +630,7 @@ abstract contract PortfolioVirtual is Objective {
         if (pairNonce == 0) revert InvalidPair();
 
         bool hasController = controller != address(0);
-        uint32 poolNonce = ++getPoolNonce;
+        uint32 poolNonce = ++getPoolNonce[pairNonce];
         poolId = FVM.encodePoolId(pairNonce, hasController, poolNonce);
 
         PortfolioPool storage pool = pools[poolId];

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -183,7 +183,7 @@ interface IPortfolioGetters {
     /**
      * @dev Incremented when a pool is created.
      */
-    function getPoolNonce() external view returns (uint32);
+    function getPoolNonce(uint24 pairNonce) external view returns (uint32);
 
     /**
      * @dev Reverse lookup to find the `pairId` of a given `asset` and `quote`.

--- a/echidna/PoolCreation.sol
+++ b/echidna/PoolCreation.sol
@@ -126,12 +126,12 @@ contract PoolCreation is EchidnaStateHandling {
         bytes memory createPoolData,
         bool hasController
     ) private returns (PortfolioPool memory pool, uint64 poolId) {
-        uint256 preCreationPoolNonce = _portfolio.getPoolNonce();
+        uint256 preCreationPoolNonce = _portfolio.getPoolNonce(pairId);
         (bool success,) = address(_portfolio).call(createPoolData);
         assert(success);
 
         // pool nonce should increase by 1 each time a pool is created
-        uint256 poolNonce = _portfolio.getPoolNonce();
+        uint256 poolNonce = _portfolio.getPoolNonce(pairId);
         assert(poolNonce == preCreationPoolNonce + 1);
 
         // pool should be created and exist

--- a/echidna/StatelessSwaps.sol
+++ b/echidna/StatelessSwaps.sol
@@ -239,7 +239,8 @@ contract StatelessSwaps is Helper, Test {
             }
         }
 
-        poolId = FVM.encodePoolId(portfolio.getPairNonce(), true, portfolio.getPoolNonce());
+        uint24 pairNonce = portfolio.getPairNonce();
+        poolId = FVM.encodePoolId(pairNonce, true, portfolio.getPoolNonce(pairNonce));
 
         console.log("PoolId", poolId);
 

--- a/test/HelperConfigsLib.sol
+++ b/test/HelperConfigsLib.sol
@@ -151,10 +151,11 @@ library Configs {
             IPortfolio(Portfolio).multiprocess(payload);
 
             bool controlled = self.controller != address(0);
+            uint24 pairNonce = IPortfolioGetters(Portfolio).getPairNonce();
             poolId = FVMLib.encodePoolId(
-                IPortfolioGetters(Portfolio).getPairNonce(),
+                pairNonce,
                 controlled,
-                IPortfolioGetters(Portfolio).getPoolNonce()
+                IPortfolioGetters(Portfolio).getPoolNonce(pairNonce)
             );
             require(poolId != 0, "ConfigLib.generate failed to createPool");
         } else {

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -37,6 +37,8 @@ import "./HelperUtils.sol" as Utils;
  */
 contract Setup is Test {
     using SafeCastLib for uint256;
+
+    uint256 internal constant JIT_LIQUIDITY_POLICY_STORAGE_SLOT = 12; // UPDATE IF STORAGE CHANGES.
     /**
      * @dev Manages the addresses calling the subjects in the environment.
      */
@@ -252,10 +254,9 @@ contract Setup is Test {
      * @dev Sets internal default jit protection seconds value to 0.
      */
     modifier noJit() {
-        uint256 LIQUIDITY_POLICY_STORAGE_SLOT = 11;
         vm.store(
             address(subject()),
-            bytes32(LIQUIDITY_POLICY_STORAGE_SLOT),
+            bytes32(JIT_LIQUIDITY_POLICY_STORAGE_SLOT),
             bytes32(0)
         );
         _;

--- a/test/invariant/HandlerPortfolio.sol
+++ b/test/invariant/HandlerPortfolio.sol
@@ -224,7 +224,7 @@ contract HandlerPortfolio is HandlerBase {
 
         // todo: make sure we create the last pool...
         uint64 poolId = FVM.encodePoolId(
-            pairId, isMutable, uint32(ctx.subject().getPoolNonce())
+            pairId, isMutable, uint32(ctx.subject().getPoolNonce(pairId))
         );
         // Add the created pool to the list of pools.
         // todo: fix assertTrue(getPool(address(subject()), poolId).lastPrice != 0, "pool-price-zero");

--- a/test/invariant/RMM01PortfolioInvariants.t.sol
+++ b/test/invariant/RMM01PortfolioInvariants.t.sol
@@ -7,7 +7,7 @@ import "./HelperInvariantLib.sol";
 import { HandlerPortfolio } from "./HandlerPortfolio.sol";
 import { HandlerExternal } from "./HandlerExternal.sol";
 
-bytes32 constant SLOT_LOCKED = bytes32(uint256(10));
+bytes32 constant SLOT_LOCKED = bytes32(uint256(11));
 
 interface AccountLike {
     function __account__() external view returns (bool);


### PR DESCRIPTION
MUST MERGE `chore/fmt` FIRST.

# Description
- Closes #214 by making `getPoolNonce` a mapping using the uint24 `pairNonce` as a key.

This expands the total amount of pools by a significant amount, since there can be 2^32 pools for all 2^24 pairs. Before, the pool nonce space was global, limiting the sum of all 2^24 pairs to 2^32 total pools.

These types were on the larger side to be conservative about the amount of pools/pairs created. However, with this mapping, we might be able to reconsider the size of both the values. Pairs take 3 bytes, pool nonces take 4 bytes, this could be potentially halved.