### PR TITLE
fix(settlement): adds sanity check at end of settlement

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -824,8 +824,6 @@ abstract contract PortfolioVirtual is Objective {
                 }
             }
 
-            // Token considered fully accounted for.
-            __account__.warm.pop();
             unchecked {
                 --i; // Cannot underflow because loop exits at 0!
             }
@@ -843,6 +841,19 @@ abstract contract PortfolioVirtual is Objective {
                 --px; // Cannot underflow because loop exits at 0!
             }
         }
+
+        // Sanity check the settlement invariant, which should be positive.
+        i = tokens.length;
+        do {
+            address token = tokens[i - 1];
+            int256 net = __account__.getNetBalance(token, address(this));
+            if (net < 0) revert NegativeBalance(token, net);
+            // Token considered fully accounted for.
+            __account__.warm.pop();
+            unchecked {
+                --i; // Cannot underflow because loop exits at 0!
+            }
+        } while (i != 0);
 
         __account__.reset(); // Clears token cache and sets `settled` to `true`.
         delete _payments;

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -68,6 +68,7 @@ error InvalidTransfer();
 error InvalidVolatility(uint24 sigma); // todo: fix, use uint16 type.
 error JitLiquidity(uint256 distance);
 error MaxFee(uint16 fee);
+error NegativeBalance(address token, int256 net);
 error NotController();
 error NonExistentPool(uint64 poolId);
 error NonExistentPosition(address owner, uint64 poolId);

--- a/contracts/test/FeeOnTransferToken.sol
+++ b/contracts/test/FeeOnTransferToken.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.8.4;
+
+import "solmate/test/utils/mocks/MockERC20.sol";
+
+contract FeeOnTransferToken is MockERC20 {
+    constructor(
+        string memory name_,
+        string memory symbol_,
+        uint8 decimals
+    ) MockERC20(name_, symbol_, decimals) { }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        super.transferFrom(from, to, amount);
+        uint256 fee = amount * 1 / 100;
+        balanceOf[to] -= fee;
+        return true;
+    }
+}

--- a/test/HelperSubjectsLib.sol
+++ b/test/HelperSubjectsLib.sol
@@ -5,6 +5,7 @@ import "contracts/RMM01Portfolio.sol";
 import "solmate/tokens/WETH.sol";
 import "solmate/test/utils/mocks/MockERC20.sol";
 import "solmate/test/utils/weird-tokens/ReturnsTooLittleToken.sol";
+import "contracts/test/FeeOnTransferToken.sol";
 import "forge-std/Test.sol";
 
 using Subjects for SubjectsState global;
@@ -145,13 +146,20 @@ library Subjects {
     ) internal ready(self) returns (SubjectsState storage) {
         (string memory name, string memory symbol, uint8 decimals) =
             abi.decode(data, (string, string, uint8));
+
+        MockERC20 token;
         if (what == "token") {
-            MockERC20 token = new MockERC20(name, symbol, decimals);
-            self.tokens.push(token);
-            self.vm.label(address(token), symbol);
-        } else if (what == "RTL") { } else {
+            token = new MockERC20(name, symbol, decimals);
+        } else if (what == "RTL") { } else if (what == "FOT") {
+            FeeOnTransferToken _token =
+                new FeeOnTransferToken(name, symbol, decimals);
+            token = MockERC20(address(_token));
+        } else {
             revert UnknownToken(what);
         }
+
+        self.tokens.push(token);
+        self.vm.label(address(token), symbol);
         return self;
     }
 

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -62,6 +62,8 @@ contract Setup is Test {
             "token", abi.encode("Asset-Std", "A-STD-18", uint8(18))
         ).token("token", abi.encode("Quote-Std", "Q-STD-18", uint8(18))).token(
             "token", abi.encode("USDC", "USDC-6", uint8(6))
+        ).token("FOT", abi.encode("Asset-FOT", "A-FOT-18", uint8(18))).token(
+            "FOT", abi.encode("Quote-FOT", "Q-FOT-18", uint8(18))
         ).stopDeploy();
 
         _ghost = GhostState({
@@ -208,6 +210,17 @@ contract Setup is Test {
         uint64 poolId = Configs.fresh().edit(
             "asset", abi.encode(address(subjects().tokens[0]))
         ).edit("quote", abi.encode(address(subjects().tokens[2]))).generate(
+            address(subject())
+        );
+
+        setGhostPoolId(poolId);
+        _;
+    }
+
+    modifier feeOnTokenTransferConfig() {
+        uint64 poolId = Configs.fresh().edit(
+            "asset", abi.encode(address(subjects().tokens[3]))
+        ).edit("quote", abi.encode(address(subjects().tokens[4]))).generate(
             address(subject())
         );
 

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -218,6 +218,19 @@ contract TestPortfolioAllocate is Setup {
         uint128 amount = 0.1 ether;
         uint64 xid = ghost().poolId;
 
+        (uint256 amount0, uint256 amount1) =
+            subject().getLiquidityDeltas(ghost().poolId, int128(amount));
+        uint256 fee0 = amount0 * 1 / 100;
+        uint256 fee1 = amount1 * 1 / 100;
+
+        // Tokens are popped, and quote token is last in allocate, so it reverts first.
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                NegativeBalance.selector,
+                ghost().quote().to_addr(),
+                -int256(fee1)
+            )
+        );
         subject().multiprocess(
             FVMLib.encodeAllocate({
                 useMax: uint8(0),
@@ -226,7 +239,7 @@ contract TestPortfolioAllocate is Setup {
             })
         );
 
-        int256 net = ghost().net(ghost().asset().to_addr());
+        int256 net = ghost().net(ghost().quote().to_addr());
 
         console.logInt(net);
         assertTrue(net >= 0, "Negative net balance for token");

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -207,4 +207,28 @@ contract TestPortfolioAllocate is Setup {
             })
         );
     }
+
+    function test_allocate_fee_on_transfer_token()
+        public
+        feeOnTokenTransferConfig
+        usePairTokens(10 ether)
+        useActor
+        isArmed
+    {
+        uint128 amount = 0.1 ether;
+        uint64 xid = ghost().poolId;
+
+        subject().multiprocess(
+            FVMLib.encodeAllocate({
+                useMax: uint8(0),
+                poolId: xid,
+                deltaLiquidity: amount
+            })
+        );
+
+        int256 net = ghost().net(ghost().asset().to_addr());
+
+        console.logInt(net);
+        assertTrue(net >= 0, "Negative net balance for token");
+    }
 }


### PR DESCRIPTION
MUST MERGE chore/fmt FIRST.

# Description
- Closes #246 by adding a sanity check at the end of the `_settlement` function to make sure the `net` balance of every token in the `warm` array has a positive value.

This is not the most efficient function because it does three loops: loop over to get payments, loop over to do payments, loop over all tokens to make sure they were settled.

This can be all done in a single loop, however, this introduces a possible attack vector via a malicious token that executes arbitrary logic in the `transferFrom` which manipulates the settlement status of some of the other tokens. In a single loop, the check for the net balance would happen in between `transferFrom`. If there was a way to take tokens out of the contract after they have been transferred in, then there would be a way to get a negative net balance even after the sanity check after the transfer from. That is pretty unlikely though.