### PR TITLE
feat(transient-opcode): adds transient state poc - adds bytecode

### DIFF
--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -174,6 +174,10 @@ struct Payment {
     uint256 amount;
 }
 
+struct TransientState {
+    address beneficiary; // Used in `allocate` to send liquidity to a target address.
+}
+
 // ===== Effects ===== //
 
 function changePoolLiquidity(

--- a/contracts/libraries/FVMLib.sol
+++ b/contracts/libraries/FVMLib.sol
@@ -39,7 +39,7 @@ bytes1 constant UNSET02 = 0x02;
 bytes1 constant DEALLOCATE = 0x03;
 bytes1 constant CLAIM = 0x04;
 bytes1 constant SWAP = 0x05;
-bytes1 constant UNSET06 = 0x06;
+bytes1 constant TRANSIENT = 0x06;
 bytes1 constant UNSET07 = 0x07;
 bytes1 constant UNSET08 = 0x08;
 bytes1 constant UNSET09 = 0x09;
@@ -353,4 +353,18 @@ function decodeSwap(bytes calldata data)
     uint8 pointer1 = uint8(data[pointer0]);
     input = AssemblyLib.toAmount(data[pointer0 + 1:pointer1]);
     output = AssemblyLib.toAmount(data[pointer1:data.length]);
+}
+
+function encodeTransient(address beneficiary)
+    pure
+    returns (bytes memory data)
+{
+    data = abi.encodePacked(TRANSIENT, beneficiary);
+}
+
+function decodeTransient(bytes calldata data)
+    pure
+    returns (address beneficiary)
+{
+    beneficiary = address(bytes20(data[1:]));
 }

--- a/test/TestPortfolioTransient.t.sol
+++ b/test/TestPortfolioTransient.t.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pragma solidity ^0.8.4;
+
+import "./Setup.sol";
+
+contract TestPortfolioTransient is Setup {
+    bytes[] instructions;
+
+    function test_transient_beneficiary()
+        public
+        defaultConfig
+        useActor
+        usePairTokens(10 ether)
+        isArmed
+    {
+        address eve = address(5);
+        uint128 liquidity = uint128(1 ether);
+        instructions.push(FVM.encodeTransient(eve));
+        instructions.push(
+            FVM.encodeAllocate(uint8(0), ghost().poolId, liquidity)
+        );
+        subject().multiprocess(FVM.encodeJumpInstruction(instructions));
+        assertEq(
+            liquidity,
+            ghost().position(eve).freeLiquidity,
+            "eve does not have the liquidity"
+        );
+    }
+}


### PR DESCRIPTION
MUST MERGE chore/fmt FIRST.

# Description
- Will close #213 and #268 by implementing a `TRANSIENT` opcode that enables the user to flag certain state, currently limited to a `beneficiary` address in this proof of concept.

This is how the feature would work, however, it pushes the contract size above the limit. Combined with the changes from the other PRs for the spearbit milestone, this would put the contract way above the limit.


We can keep this open to discuss later, but pretty unlikely we put this change in given the bytecode added.