### PR TITLE
feat(invariant-getter): adds getInvariant function to virtual Portfolio

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -899,4 +899,16 @@ abstract contract PortfolioVirtual is Objective {
     {
         return pools[poolId].getPoolVirtualReserves();
     }
+
+    /// @inheritdoc IPortfolioGetters
+    function getInvariant(uint64 poolId)
+        public
+        view
+        override
+        returns (int256 invariant)
+    {
+        (, invariant) = checkInvariant(
+            poolId, 0, pools[poolId].virtualX, pools[poolId].virtualY
+        );
+    }
 }

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -307,6 +307,11 @@ interface IPortfolioGetters {
         external
         view
         returns (uint256 price);
+
+    function getInvariant(uint64 poolid)
+        external
+        view
+        returns (int256 invariant);
 }
 
 interface IPortfolioActions {

--- a/test/TestRMM01.t.sol
+++ b/test/TestRMM01.t.sol
@@ -36,4 +36,9 @@ contract TestRMM01 is
     function test_version() public {
         assertEq(subject().VERSION(), "v1.0.0-beta", "version-not-equal");
     }
+
+    function test_getInvariant() public defaultConfig {
+        int256 invariant = subject().getInvariant(ghost().poolId);
+        assertEq(invariant, 0, "non-zero-invariant");
+    }
 }


### PR DESCRIPTION
MUST MERGE chore/fmt FIRST.

# Description
- Closes #208 by implementing a `getInvariant` function in the `Portfolio.sol` virtual contract, which uses the virtual function `checkInvariant` to return the CURRENT invariant of a pool.