### PR TITLE
fix(invariant-tests): updates createActor modifier to not set the actor

### DIFF
--- a/test/HelperConfigsLib.sol
+++ b/test/HelperConfigsLib.sol
@@ -171,6 +171,11 @@ library Configs {
                 price: self.reportedPriceWad
             });
             IPortfolio(Portfolio).multiprocess(payload);
+            bool controlled = self.controller != address(0);
+            poolId = FVMLib.encodePoolId(
+                pairId, controlled, IPortfolioGetters(Portfolio).getPoolNonce()
+            );
+            require(poolId != 0, "ConfigLib.generate failed to createPool");
         }
     }
 }

--- a/test/HelperConfigsLib.sol
+++ b/test/HelperConfigsLib.sol
@@ -173,7 +173,9 @@ library Configs {
             IPortfolio(Portfolio).multiprocess(payload);
             bool controlled = self.controller != address(0);
             poolId = FVMLib.encodePoolId(
-                pairId, controlled, IPortfolioGetters(Portfolio).getPoolNonce()
+                pairId,
+                controlled,
+                IPortfolioGetters(Portfolio).getPoolNonce(pairId)
             );
             require(poolId != 0, "ConfigLib.generate failed to createPool");
         }

--- a/test/invariant/HandlerPortfolio.sol
+++ b/test/invariant/HandlerPortfolio.sol
@@ -351,13 +351,13 @@ contract HandlerPortfolio is HandlerBase {
 
         // If the user has to pay externally, give them tokens.
         if (transferAssetIn) {
-            ctx.ghost().asset().to_token().mint(
-                ctx.actor(), physicalAssetPayment
+            ctx.ghost().asset().prepare(
+                ctx.actor(), address(ctx.subject()), physicalAssetPayment
             );
         }
         if (transferQuoteIn) {
-            ctx.ghost().quote().to_token().mint(
-                ctx.actor(), physicalQuotePayment
+            ctx.ghost().quote().prepare(
+                ctx.actor(), address(ctx.subject()), physicalQuotePayment
             );
         }
 
@@ -450,7 +450,6 @@ contract HandlerPortfolio is HandlerBase {
 
         // Get some liquidity.
         PortfolioPosition memory pos = ctx.ghost().position(ctx.actor());
-        require(pos.freeLiquidity >= deltaLiquidity, "Not enough liquidity");
 
         if (pos.freeLiquidity >= deltaLiquidity) {
             // Preconditions

--- a/test/invariant/setup/HandlerBase.sol
+++ b/test/invariant/setup/HandlerBase.sol
@@ -86,7 +86,6 @@ abstract contract HandlerBase is
 
     modifier createActor() {
         ctx.addGhostActor(msg.sender);
-        ctx.setGhostActor(msg.sender);
         _;
     }
 


### PR DESCRIPTION
# Description
- Fixes invariant tests by avoiding the auto reverting tx from "already having a prank active"
- Updates config to return poolId if not creating a pair