### PR TITLE
chore(ci): updates ci to skip test files on optimized build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,5 +19,5 @@ jobs:
         with:
           version: nightly
 
-      - name: Run tests
-        run: FOUNDRY_PROFILE=optimized forge build --sizes
+      - name: Run build
+        run: FOUNDRY_PROFILE=optimized forge build --sizes --skip test


### PR DESCRIPTION
# Description
- Optimized build was taking long because it was optimizing the test contracts.... yikes.