### PR TITLE
Audit fix/to bytes8/16

### DIFF
--- a/contracts/libraries/AssemblyLib.sol
+++ b/contracts/libraries/AssemblyLib.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.13;
 
 error InvalidLiquidity();
 error InvalidDays();
+error DataTooLong();
 
 uint256 constant SECONDS_PER_YEAR = 31556953 seconds;
 uint256 constant SECONDS_PER_DAY = 86_400 seconds;
@@ -154,7 +155,14 @@ library AssemblyLib {
      * handles it for us.
      */
     function toBytes16(bytes memory raw) internal pure returns (bytes16 data) {
+        bytes4 errorSelector = DataTooLong.selector;
+
         assembly {
+            if gt(mload(raw), 16) {
+                mstore(0, errorSelector)
+                revert(0, 4)
+            }
+
             data := mload(add(raw, 32))
             let shift := mul(sub(16, mload(raw)), 8)
             data := shr(shift, data)
@@ -166,7 +174,14 @@ library AssemblyLib {
      * handles it for us.
      */
     function toBytes8(bytes memory raw) internal pure returns (bytes8 data) {
+        bytes4 errorSelector = DataTooLong.selector;
+
         assembly {
+            if gt(mload(raw), 8) {
+                mstore(0, errorSelector)
+                revert(0, 4)
+            }
+
             data := mload(add(raw, 32))
             let shift := mul(sub(8, mload(raw)), 8)
             data := shr(shift, data)

--- a/test/TestAssemblyLib.t.sol
+++ b/test/TestAssemblyLib.t.sol
@@ -50,4 +50,44 @@ contract TestAssemblyLib is Test {
         assertEq(output, hex"02");
     }
     */
+
+    function test_toBytes16() public {
+        bytes memory input = hex"1234567890abcdef1234567890abcdef";
+        bytes16 expectedOutput = hex"1234567890abcdef1234567890abcdef";
+        bytes16 output = AssemblyLib.toBytes16(input);
+        assertEq(output, expectedOutput);
+    }
+
+    function test_toBytes16_RightPad() public {
+        bytes memory input = hex"01";
+        bytes16 expectedOutput = hex"00000000000000000000000000000001";
+        bytes16 output = AssemblyLib.toBytes16(input);
+        assertEq(output, expectedOutput);
+    }
+
+    function test_toBytes16_RevertIfLengthTooLong() public {
+        bytes memory input = hex"1234567890abcdef1234567890abcdef00";
+        vm.expectRevert(DataTooLong.selector);
+        AssemblyLib.toBytes16(input);
+    }
+
+    function test_toBytes8() public {
+        bytes memory input = hex"1234567890abcdef";
+        bytes16 expectedOutput = hex"1234567890abcdef";
+        bytes16 output = AssemblyLib.toBytes8(input);
+        assertEq(output, expectedOutput);
+    }
+
+    function test_toBytes8_RightPad() public {
+        bytes memory input = hex"01";
+        bytes16 expectedOutput = hex"0000000000000001";
+        bytes16 output = AssemblyLib.toBytes8(input);
+        assertEq(output, expectedOutput);
+    }
+
+    function test_toBytes8_RevertIfLengthTooLong() public {
+        bytes memory input = hex"1234567890abcdef00";
+        vm.expectRevert(DataTooLong.selector);
+        AssemblyLib.toBytes8(input);
+    }
 }


### PR DESCRIPTION
Functions converting `bytes` to `bytes8` or `bytes16` were not enforcing the length of the data, so I added a length check in both functions (cf https://github.com/spearbit-audits/review-primitive/issues/21).