### PR TITLE
Returned results from the multiprocess function

### DIFF
--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -337,7 +337,7 @@ interface IPortfolioActions {
      *
      * todo: Update multiprocess to return data, or information that can help debugging.
      */
-    function multiprocess(bytes calldata data) external payable;
+    function multiprocess(bytes calldata data) external payable returns (bytes[] memory output);
 
     /**
      * @notice Assigns `amount` of `token` to `msg.sender` internal balance.

--- a/contracts/libraries/FVMLib.sol
+++ b/contracts/libraries/FVMLib.sol
@@ -95,9 +95,11 @@ error InvalidBytesLength(uint256 expected, uint256 length); // 0xe19dc95e
  * | bytes[ptr[0] + 1]          | ptr[1] := Length of instruction[1] |
  * | ...                        | Repeats in a loop for each instruction. |
  */
-function _jumpProcess(bytes calldata data, function(bytes calldata) _process) {
+function _jumpProcess(bytes calldata data, function(bytes calldata) returns (bytes memory) _process) returns (bytes[] memory results) {
     // Encoded `data`:| 0x | opcode | amount instructions | instruction length | instruction |
     uint8 totalInstructions = uint8(data[1]);
+    results = new bytes[](totalInstructions);
+
     // The "pointer" is pointing to the first byte of an instruction,
     // which holds the data for the instruction's length in bytes.
     uint256 idxPtr = JUMP_PROCESS_START_POINTER;
@@ -125,7 +127,7 @@ function _jumpProcess(bytes calldata data, function(bytes calldata) _process) {
         idxPtr = idxInstructionEnd;
         // Process the instruction after removing the instruction length,
         // so only instruction data is passed to `_process`.
-        _process(instruction[1:]);
+        results[i] = _process(instruction[1:]);
     }
 }
 

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -414,4 +414,35 @@ contract TestPortfolioAllocate is Setup {
             "position.freeLiquidity != pool.liquidity"
         );
     }
+
+    function test_allocate_returned_results()
+        public
+        defaultConfig
+        useActor
+        usePairTokens(10 ether)
+        isArmed
+    {
+        uint128 amount = 0.1 ether;
+        uint64 xid = ghost().poolId;
+
+        (uint256 delta0, uint256 delta1) = ghost().pool().getPoolLiquidityDeltas({
+            deltaLiquidity: int128(amount)
+        });
+        bytes[] memory results = subject().multiprocess(
+            FVMLib.encodeAllocateOrDeallocate({
+                shouldAllocate: true,
+                useMax: uint8(0),
+                poolId: xid,
+                deltaLiquidity: amount
+            })
+        );
+
+        (uint128 deltaAsset, uint128 deltaQuote) = abi.decode(
+            results[0],
+            (uint128, uint128)
+        );
+
+        assertEq(deltaAsset, delta0, "deltaAsset");
+        assertEq(deltaQuote, delta1, "deltaQuote");
+    }
 }

--- a/test/TestPortfolioCreatePair.t.sol
+++ b/test/TestPortfolioCreatePair.t.sol
@@ -11,12 +11,12 @@ contract TestPortfolioCreatePair is Setup {
         subject().multiprocess(data);
     }
 
-    function test_createPair_result() public {
+    function test_createPair_returned_results() public {
         address token0 = address(new MockERC20("tkn", "tkn", 18));
         address token1 = address(new MockERC20("tkn", "tkn", 18));
         bytes memory data = FVMLib.encodeCreatePair(token0, token1);
-        bytes[] memory result = subject().multiprocess(data);
-        uint24 pairId = abi.decode(result[0], (uint24));
+        bytes[] memory results = subject().multiprocess(data);
+        uint24 pairId = abi.decode(results[0], (uint24));
         assertEq(pairId, 1);
     }
 

--- a/test/TestPortfolioCreatePair.t.sol
+++ b/test/TestPortfolioCreatePair.t.sol
@@ -11,6 +11,15 @@ contract TestPortfolioCreatePair is Setup {
         subject().multiprocess(data);
     }
 
+    function test_createPair_result() public {
+        address token0 = address(new MockERC20("tkn", "tkn", 18));
+        address token1 = address(new MockERC20("tkn", "tkn", 18));
+        bytes memory data = FVMLib.encodeCreatePair(token0, token1);
+        bytes[] memory result = subject().multiprocess(data);
+        uint24 pairId = abi.decode(result[0], (uint24));
+        assertEq(pairId, 1);
+    }
+
     function test_revert_createPair_same_token() public {
         address token0 = address(new MockERC20("tkn", "tkn", 18));
         bytes memory data = FVMLib.encodeCreatePair(token0, token0);

--- a/test/TestPortfolioSwap.t.sol
+++ b/test/TestPortfolioSwap.t.sol
@@ -103,4 +103,38 @@ contract TestPortfolioSwap is Setup {
         uint256 postBal = ghost().asset().to_token().balanceOf(address(this));
         assertTrue(postBal > preBal, "nothing claimed");
     }
+
+    function test_swap_returned_results()
+        public
+        defaultConfig
+        useActor
+        usePairTokens(10 ether)
+        allocateSome(1 ether)
+        isArmed
+    {
+        // Estimate amount out.
+        bool sellAsset = true;
+        uint128 amtIn = 0.1 ether;
+        uint128 amtOut =
+            uint128(subject().getAmountOut(ghost().poolId, sellAsset, amtIn));
+
+        bytes[] memory results = subject().multiprocess(
+            FVMLib.encodeSwap(
+                uint8(0),
+                ghost().poolId,
+                amtIn,
+                amtOut,
+                uint8(sellAsset ? 1 : 0)
+            )
+        );
+
+        (uint64 poolId, uint256 input, uint256 output) = abi.decode(
+            results[0],
+            (uint64, uint256, uint256)
+        );
+
+        assertEq(poolId, ghost().poolId);
+        assertEq(input, amtIn);
+        assertEq(output, amtOut);
+    }
 }


### PR DESCRIPTION
Calling the `multiprocess` function will now return the values of the functions that were called. It works almost the same way as a `Multicall` contract: returned values are packed using `abi.encode` and then stored in an array of `bytes`. This array called `results` will have `x` elements, `x` being the amount of functions that were called.