### PR TITLE
fix(sprbt-12): removes invariant scaling in RMM01Portfolio

### DIFF
--- a/contracts/RMM01Portfolio.sol
+++ b/contracts/RMM01Portfolio.sol
@@ -102,14 +102,7 @@ contract RMM01Portfolio is PortfolioVirtual {
             R_y: reserveY,
             timeRemainingSec: tau
         });
-
-        // Invariant for RMM01 is denominated in the `quote` token.
-        int256 liveInvariantWad =
-            invariant.scaleFromWadDownSigned(pools[poolId].pair.decimalsQuote);
-        int256 nextInvariantWad = nextInvariant.scaleFromWadDownSigned(
-            pools[poolId].pair.decimalsQuote
-        );
-        return (nextInvariantWad >= liveInvariantWad, nextInvariant);
+        return (nextInvariant >= invariant, nextInvariant);
     }
 
     /// @inheritdoc Objective

--- a/contracts/libraries/AssemblyLib.sol
+++ b/contracts/libraries/AssemblyLib.sol
@@ -313,16 +313,6 @@ library AssemblyLib {
         }
     }
 
-    function scaleFromWadDownSigned(
-        int256 amountWad,
-        uint256 decimals
-    ) internal pure returns (int256 outputDec) {
-        int256 factor = int256(computeScalar(decimals));
-        assembly {
-            outputDec := sdiv(amountWad, factor)
-        }
-    }
-
     /*
 
     /!\ Do not use this function, it's completely cursed:


### PR DESCRIPTION
See https://github.com/spearbit-audits/review-primitive/issues/12
See https://github.com/spearbit-audits/review-primitive/issues/19

# Description
## SPRBT-12
Removes logic in `RMM01Portfolio` `checkInvariant` function which scaled the invariant from WAD units to the decimal units of the quote token. Removing this logic forces the invariant check to have 18 units of precision. This means that swap output amounts must be precise to pass the more precise invariant check, which the current onchain method in the Portfolio contract `getAmountOut` might not be able to offer currently. A pending PR makes this more precise, see #316 .

## SPRBT-19
Removes `AssemblyLib.scaleFromWadDownSigned` because it's only use was removed in the above code that was removed in the `checkInvariant` function.


# Blockers
Waiting on spearbit/post-audit branch to resolve the stack too deep error, so the CI tests can properly pass.