### PR TITLE
INVALID fix(sprbt-14): removes liquidity parameter from _syncPool

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -247,7 +247,9 @@ abstract contract PortfolioVirtual is Objective {
         (deltaAsset, deltaQuote) =
             getLiquidityDeltas(poolId, AssemblyLib.toInt128(deltaLiquidity)); // note: Rounds up.
         if (deltaAsset == 0 || deltaQuote == 0) revert ZeroAmounts();
-        if (deltaAsset > maxDeltaAsset || deltaQuote > maxDeltaQuote) revert MaxDeltaReached();
+        if (deltaAsset > maxDeltaAsset || deltaQuote > maxDeltaQuote) {
+            revert MaxDeltaReached();
+        }
 
         ChangeLiquidityParams memory args = ChangeLiquidityParams({
             owner: msg.sender,
@@ -288,7 +290,9 @@ abstract contract PortfolioVirtual is Objective {
         if (deltaLiquidity == 0) revert ZeroLiquidity();
         (deltaAsset, deltaQuote) =
             getLiquidityDeltas(poolId, -AssemblyLib.toInt128(deltaLiquidity)); // note: Rounds down.
-        if (deltaAsset < minDeltaAsset || deltaQuote < minDeltaQuote) revert MinDeltaUnmatched();
+        if (deltaAsset < minDeltaAsset || deltaQuote < minDeltaQuote) {
+            revert MinDeltaUnmatched();
+        }
         ChangeLiquidityParams memory args = ChangeLiquidityParams({
             owner: msg.sender,
             poolId: poolId,
@@ -310,9 +314,7 @@ abstract contract PortfolioVirtual is Objective {
     /**
      * @dev Manipulates reserves depending on if liquidity is being allocated or deallocated.
      */
-    function _changeLiquidity(ChangeLiquidityParams memory args)
-        internal
-    {
+    function _changeLiquidity(ChangeLiquidityParams memory args) internal {
         (PortfolioPool storage pool, PortfolioPosition storage position) =
             (pools[args.poolId], positions[args.owner][args.poolId]);
 
@@ -498,12 +500,7 @@ abstract contract PortfolioVirtual is Objective {
 
         // =---= Effects =---= //
 
-        _syncPool(
-            args.poolId,
-            iteration.virtualX,
-            iteration.virtualY,
-            iteration.liquidity
-        );
+        _syncPool(args.poolId, iteration.virtualX, iteration.virtualY);
 
         // -=- Scale Amounts to Native Token Decimals -=- //
         {
@@ -551,14 +548,12 @@ abstract contract PortfolioVirtual is Objective {
     function _syncPool(
         uint64 poolId,
         uint256 nextVirtualX,
-        uint256 nextVirtualY,
-        uint256 liquidity
+        uint256 nextVirtualY
     ) internal {
         PortfolioPool storage pool = pools[poolId];
 
         pool.virtualX = nextVirtualX.safeCastTo128();
         pool.virtualY = nextVirtualY.safeCastTo128();
-        pool.liquidity = liquidity.safeCastTo128();
         pool.syncPoolTimestamp(block.timestamp);
     }
 
@@ -660,7 +655,7 @@ abstract contract PortfolioVirtual is Objective {
             pool.params.duration,
             pool.params.volatility,
             pool.params.priorityFee
-        );
+            );
     }
 
     // ===== Accounting System ===== //
@@ -730,21 +725,41 @@ abstract contract PortfolioVirtual is Objective {
     function _process(bytes calldata data) internal {
         (, bytes1 instruction) = AssemblyLib.separate(data[0]); // Upper byte is useMax, lower byte is instruction.
 
-        if (
-            instruction == FVM.SWAP_ASSET || instruction == FVM.SWAP_QUOTE
-        ) {
+        if (instruction == FVM.SWAP_ASSET || instruction == FVM.SWAP_QUOTE) {
             Order memory args;
             (args.useMax, args.poolId, args.input, args.output, args.sellAsset)
             = FVM.decodeSwap(data);
             _swap(args);
         } else if (instruction == FVM.ALLOCATE) {
-            (uint8 useMax, uint64 poolId, uint128 deltaLiquidity, uint128 maxDeltaAsset, uint128 maxDeltaQuote) =
-                FVM.decodeAllocateOrDeallocate(data);
-            _allocate(useMax == 1, poolId, deltaLiquidity, maxDeltaAsset, maxDeltaQuote);
+            (
+                uint8 useMax,
+                uint64 poolId,
+                uint128 deltaLiquidity,
+                uint128 maxDeltaAsset,
+                uint128 maxDeltaQuote
+            ) = FVM.decodeAllocateOrDeallocate(data);
+            _allocate(
+                useMax == 1,
+                poolId,
+                deltaLiquidity,
+                maxDeltaAsset,
+                maxDeltaQuote
+            );
         } else if (instruction == FVM.DEALLOCATE) {
-            (uint8 useMax, uint64 poolId, uint128 deltaLiquidity, uint128 minDeltaAsset, uint128 minDeltaQuote) =
-                FVM.decodeAllocateOrDeallocate(data);
-            _deallocate(useMax == 1, poolId, deltaLiquidity, minDeltaAsset, minDeltaQuote);
+            (
+                uint8 useMax,
+                uint64 poolId,
+                uint128 deltaLiquidity,
+                uint128 minDeltaAsset,
+                uint128 minDeltaQuote
+            ) = FVM.decodeAllocateOrDeallocate(data);
+            _deallocate(
+                useMax == 1,
+                poolId,
+                deltaLiquidity,
+                minDeltaAsset,
+                minDeltaQuote
+            );
         } else if (instruction == FVM.CREATE_POOL) {
             (
                 uint24 pairId,
@@ -771,7 +786,7 @@ abstract contract PortfolioVirtual is Objective {
         } else if (instruction == FVM.CREATE_PAIR) {
             (address asset, address quote) = FVM.decodeCreatePair(data);
             _createPair(asset, quote);
-        }  else {
+        } else {
             revert InvalidInstruction();
         }
     }


### PR DESCRIPTION
Invalid: see https://github.com/primitivefinance/portfolio/pull/333

See https://github.com/spearbit-audits/review-primitive/issues/14
# Description
Removes `liquidity` parameter from `_syncPool` function because liquidity remains unchained in `_swap`, the only place where `_syncPool` is called.

Does not remove the update to the lastTimestamp, since this is an important update that is used in consecutive swaps to compute `lastTau`.