### PR TITLE
fix(sprbt-14): updates _syncPool to not update pool.liquidity

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -500,12 +500,7 @@ abstract contract PortfolioVirtual is Objective {
 
         // =---= Effects =---= //
 
-        _syncPool(
-            args.poolId,
-            iteration.virtualX,
-            iteration.virtualY,
-            iteration.liquidity
-        );
+        _syncPool(args.poolId, iteration.virtualX, iteration.virtualY);
 
         // -=- Scale Amounts to Native Token Decimals -=- //
         {
@@ -553,14 +548,12 @@ abstract contract PortfolioVirtual is Objective {
     function _syncPool(
         uint64 poolId,
         uint256 nextVirtualX,
-        uint256 nextVirtualY,
-        uint256 liquidity
+        uint256 nextVirtualY
     ) internal {
         PortfolioPool storage pool = pools[poolId];
 
         pool.virtualX = nextVirtualX.safeCastTo128();
         pool.virtualY = nextVirtualY.safeCastTo128();
-        pool.liquidity = liquidity.safeCastTo128();
         pool.syncPoolTimestamp(block.timestamp);
     }
 

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -554,7 +554,11 @@ abstract contract PortfolioVirtual is Objective {
 
         pool.virtualX = nextVirtualX.safeCastTo128();
         pool.virtualY = nextVirtualY.safeCastTo128();
-        pool.syncPoolTimestamp(block.timestamp);
+
+        // If not updated in the other swap hooks, update the timestamp.
+        if (pool.lastTimestamp != block.timestamp) {
+            pool.syncPoolTimestamp(block.timestamp);
+        }
     }
 
     function _createPair(


### PR DESCRIPTION
Must merge `fix/formatting` branch into `spearbit/post-audit` branch first.

See https://github.com/spearbit-audits/review-primitive/issues/14

# Description
Removes `liquidity` parameter from `_syncPool` function because liquidity remains unchained in `_swap`, the only place where `_syncPool` is called.

Does not remove the update to the lastTimestamp, since this is an important update that is used in consecutive swaps to compute `lastTau`.