### PR TITLE
fix(sprbt-11, sprbt-9): updates protocol fee logic, removed from inpu…

### DIFF
--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -132,15 +132,16 @@ struct Order {
 }
 
 struct Iteration {
-    int256 prevInvariant;
-    int256 nextInvariant;
-    uint256 virtualX;
-    uint256 virtualY;
-    uint256 remainder;
-    uint256 feeAmount;
-    uint256 liquidity;
-    uint256 input;
-    uint256 output;
+    int256 prevInvariant; // WAD
+    int256 nextInvariant; // WAD
+    uint256 virtualX; // WAD
+    uint256 virtualY; // WAD
+    uint256 remainder; // WAD
+    uint256 feeAmount; // WAD
+    uint256 protocolFeeAmount; // WAD
+    uint256 liquidity; // WAD
+    uint256 input; // DEC -> WAD -> DEC
+    uint256 output; // DEC -> WAD -> DEC
 }
 
 struct SwapState {


### PR DESCRIPTION
…t and scaled correctly

Do not merge until fix/formatting branch is merged.

See https://github.com/spearbit-audits/review-primitive/issues/11 and https://github.com/spearbit-audits/review-primitive/issues/9

# Changes
- Adds `protocolFeeAmount` to `Iteration` struct.
- Renames variable in swap, protocolFeeAmount -> protocolFeeAmountWad, for clarity
- Removes `protocolFeeAmountWad` from `deltaInput` (WAD) and `feeAmount` (WAD)
- After swap, checks if `iteration.protocolFeeAmount != 0`. If true, scales protocolFeeAmount from WAD to DEC (decimals of input token) before applying the credit to the REGISTRY address.