### PR TITLE
Audit fix/virtual reserves

### DIFF
--- a/contracts/Objective.sol
+++ b/contracts/Objective.sol
@@ -14,13 +14,14 @@ import "./interfaces/IPortfolioRegistry.sol";
 abstract contract Objective is IPortfolio {
     /**
      * @dev Used to apply changes to a `pool`, like it's timestamp, before a swap occurs.
+     * @param sellAsset Determines rounding direction for reserves to compute invariant, round Y up (true) or round X up (false).
      * @return success True if pool can be swapped in.
      * @return invariant Current invariant value of the pool in WAD units.
      */
-    function _beforeSwapEffects(uint64 poolId)
-        internal
-        virtual
-        returns (bool success, int256 invariant);
+    function _beforeSwapEffects(
+        uint64 poolId,
+        bool sellAsset
+    ) internal virtual returns (bool success, int256 invariant);
 
     /**
      * @dev Conditional check made before changing `pool.liquidity` and `position.freeLiquidity`.

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -927,14 +927,16 @@ abstract contract PortfolioVirtual is Objective {
             // Only `credited` or `remainder` can be non-zero.
             // Outstanding amount must be transferred in to `address(this)`.
             // Untracked credits must be transferred out to `msg.sender`.
-            _payments.push(
-                Payment({
-                    token: token,
-                    amountTransferTo: credited, // Reserves are not tracking some tokens.
-                    amountTransferFrom: remainder, // Reserves need more tokens.
-                    balance: Account.__balanceOf__(token, address(this))
-                })
-            );
+            if (credited != 0 || remainder != 0) {
+                _payments.push(
+                    Payment({
+                        token: token,
+                        amountTransferTo: credited, // Reserves are not tracking some tokens.
+                        amountTransferFrom: remainder, // Reserves need more tokens.
+                        balance: Account.__balanceOf__(token, address(this))
+                    })
+                );
+            }
 
             // Token considered fully accounted for.
             __account__.warm.pop();
@@ -982,9 +984,7 @@ abstract contract PortfolioVirtual is Objective {
                         token, int256(post) - int256(expected)
                     );
                 }
-            }
-
-            if (amountTransferFrom > 0) {
+            } else if (amountTransferFrom > 0) {
                 uint256 prev = payments[index].balance;
 
                 // Interaction

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -434,7 +434,8 @@ abstract contract PortfolioVirtual is Objective {
         // -=- Load Swap Info -=- //
         Iteration memory iteration;
         {
-            (bool success, int256 invariant) = _beforeSwapEffects(args.poolId);
+            (bool success, int256 invariant) =
+                _beforeSwapEffects(args.poolId, _state.sell);
             if (!success) revert PoolExpired();
 
             if (args.useMax == 1) {

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -35,7 +35,7 @@ using {
     computeTau
 } for PortfolioPool global;
 
-uint256 constant BURNED_LIQUIDITY = 1e3;
+uint256 constant BURNED_LIQUIDITY = 1e9;
 uint256 constant INIT_LIQUIDITY = 1e18;
 uint256 constant PERCENTAGE = 10_000;
 uint256 constant MIN_MAX_PRICE = 1;

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -35,6 +35,7 @@ using {
     computeTau
 } for PortfolioPool global;
 
+uint256 constant BURNED_LIQUIDITY = 1e3;
 uint256 constant INIT_LIQUIDITY = 1e18;
 uint256 constant PERCENTAGE = 10_000;
 uint256 constant MIN_MAX_PRICE = 1;
@@ -49,6 +50,7 @@ uint256 constant JUST_IN_TIME_MAX = 600 seconds;
 uint256 constant JUST_IN_TIME_LIQUIDITY_POLICY = 4 seconds;
 
 error DrawBalance();
+error InsufficientLiquidity();
 error InvalidDecimals(uint8 decimals);
 error InvalidDuration(uint16);
 error InvalidFee(uint16 fee);

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -9,6 +9,7 @@ import "./libraries/AccountLib.sol" as Account;
 
 using AssemblyLib for uint256;
 using FixedPointMathLib for uint256;
+using FixedPointMathLib for uint128;
 using FixedPointMathLib for int256;
 using SafeCastLib for uint256;
 
@@ -23,8 +24,8 @@ using {
     changePoolLiquidity,
     changePoolParameters,
     exists,
-    getVirtualReservesPerLiquidity,
-    getVirtualPoolReservesPerLiquidityInWad,
+    getVirtualReservesDec,
+    getVirtualReservesWad,
     getPoolLiquidityDeltas,
     getPoolMaxLiquidity,
     getPoolReserves,
@@ -34,6 +35,7 @@ using {
     computeTau
 } for PortfolioPool global;
 
+uint256 constant INIT_LIQUIDITY = 1e18;
 uint256 constant PERCENTAGE = 10_000;
 uint256 constant MIN_MAX_PRICE = 1;
 uint256 constant MAX_MAX_PRICE = type(uint128).max;
@@ -198,7 +200,9 @@ function getPoolReserves(PortfolioPool memory self)
     pure
     returns (uint128 reserveAsset, uint128 reserveQuote)
 {
-    return self.getPoolLiquidityDeltas(-int128(self.liquidity)); // Rounds down.
+    return self.getPoolLiquidityDeltas(
+        -int128(self.liquidity == 0 ? uint128(INIT_LIQUIDITY) : self.liquidity)
+    ); // Rounds down.
 }
 
 /**
@@ -214,10 +218,13 @@ function getPoolMaxLiquidity(
     deltaAsset = deltaAsset.scaleToWad(self.pair.decimalsAsset).safeCastTo128();
     deltaQuote = deltaQuote.scaleToWad(self.pair.decimalsQuote).safeCastTo128();
 
+    uint256 totalLiquidity = self.liquidity;
+    if (totalLiquidity == 0) totalLiquidity = INIT_LIQUIDITY; // use 1E18 of liquidity
+
     (uint256 amountAssetWad, uint256 amountQuoteWad) =
-        self.getVirtualPoolReservesPerLiquidityInWad();
-    uint256 liquidity0 = deltaAsset.divWadDown(amountAssetWad); // L_0 = X / (X / L)
-    uint256 liquidity1 = deltaQuote.divWadDown(amountQuoteWad); // L_1 = Y / (Y / L)
+        self.getVirtualReservesWad();
+    uint256 liquidity0 = deltaAsset.mulDivDown(totalLiquidity, amountAssetWad); // L_0 = dX * L / X
+    uint256 liquidity1 = deltaQuote.mulDivDown(totalLiquidity, amountQuoteWad); // L_1 = dY * L / Y
     deltaLiquidity = AssemblyLib.min(liquidity0, liquidity1).safeCastTo128();
 }
 
@@ -229,43 +236,47 @@ function getPoolLiquidityDeltas(
     int128 deltaLiquidity
 ) pure returns (uint128 deltaAsset, uint128 deltaQuote) {
     if (deltaLiquidity == 0) return (deltaAsset, deltaQuote);
+    uint256 delta =
+        deltaLiquidity > 0 ? uint128(deltaLiquidity) : uint128(-deltaLiquidity);
 
     (uint256 amountAssetWad, uint256 amountQuoteWad) =
-        self.getVirtualPoolReservesPerLiquidityInWad();
-    uint256 scaleDownFactorAsset = AssemblyLib.computeScalar(
-        self.pair.decimalsAsset
-    ) * FixedPointMathLib.WAD;
-    uint256 scaleDownFactorQuote = AssemblyLib.computeScalar(
-        self.pair.decimalsQuote
-    ) * FixedPointMathLib.WAD;
+        self.getVirtualReservesWad();
 
-    uint256 delta;
-    if (deltaLiquidity > 0) {
-        delta = uint128(deltaLiquidity);
-        deltaAsset =
-            amountAssetWad.mulDivUp(delta, scaleDownFactorAsset).safeCastTo128();
-        deltaQuote =
-            amountQuoteWad.mulDivUp(delta, scaleDownFactorQuote).safeCastTo128();
-    } else {
-        delta = uint128(-deltaLiquidity);
-        deltaAsset = amountAssetWad.mulDivDown(delta, scaleDownFactorAsset)
-            .safeCastTo128();
-        deltaQuote = amountQuoteWad.mulDivDown(delta, scaleDownFactorQuote)
-            .safeCastTo128();
+    // Pre-allocate pools initialize reserves to 1E18 of liquidity to
+    // compute the first allocate quantities.
+    if (self.liquidity == 0) {
+        uint256 scaleDownFactorAsset = AssemblyLib.computeScalar(
+            self.pair.decimalsAsset
+        ) * FixedPointMathLib.WAD;
+        uint256 scaleDownFactorQuote = AssemblyLib.computeScalar(
+            self.pair.decimalsQuote
+        ) * FixedPointMathLib.WAD;
+
+        amountAssetWad = delta.mulDivUp(amountAssetWad, scaleDownFactorAsset);
+        amountQuoteWad = delta.mulDivUp(amountQuoteWad, scaleDownFactorQuote);
+        return (amountAssetWad.safeCastTo128(), amountQuoteWad.safeCastTo128());
     }
+
+    amountAssetWad = delta.mulDivUp(amountAssetWad, self.liquidity);
+    amountQuoteWad = delta.mulDivUp(amountQuoteWad, self.liquidity);
+
+    (deltaAsset, deltaQuote) = (
+        amountAssetWad.scaleFromWadDown(self.pair.decimalsAsset).safeCastTo128(),
+        amountQuoteWad.scaleFromWadDown(self.pair.decimalsQuote).safeCastTo128()
+    );
 }
 
 /**
- * @dev Scales virtual reserves per liquidity from WAD to native token decimal units.
- * @return amountAssetDec Quantity of `asset` tokens in native decimal units per WAD unit of liquidity.
- * @return amountQuoteDec Quantity of `quote` tokens in native decimal units per WAD unit of liquidity.
+ * @dev Scales virtual reserves from WAD to native token decimal units.
+ * @return amountAssetDec Quantity of `asset` tokens in native decimal units.
+ * @return amountQuoteDec Quantity of `quote` tokens in native decimal units.
  */
-function getVirtualReservesPerLiquidity(PortfolioPool memory self)
+function getVirtualReservesDec(PortfolioPool memory self)
     pure
     returns (uint128 amountAssetDec, uint128 amountQuoteDec)
 {
     (uint256 amountAssetWad, uint256 amountQuoteWad) =
-        self.getVirtualPoolReservesPerLiquidityInWad();
+        self.getVirtualReservesWad();
     amountAssetDec =
         amountAssetWad.scaleFromWadDown(self.pair.decimalsAsset).safeCastTo128();
     amountQuoteDec =
@@ -273,11 +284,11 @@ function getVirtualReservesPerLiquidity(PortfolioPool memory self)
 }
 
 /**
- * @dev Virtual reserves of tokens in WAD units per WAD units of liquidity.
- * @return amountAssetWad Quantity of `asset` tokens in WAD units per WAD of liquidity.
- * @return amountQuoteWad Quantity of `quote` tokens in WAD units per WAD of liquidity.
+ * @dev Virtual reserves of tokens in WAD units.
+ * @return amountAssetWad Quantity of `asset` tokens in WAD units.
+ * @return amountQuoteWad Quantity of `quote` tokens in WAD units.
  */
-function getVirtualPoolReservesPerLiquidityInWad(PortfolioPool memory self)
+function getVirtualReservesWad(PortfolioPool memory self)
     pure
     returns (uint128 amountAssetWad, uint128 amountQuoteWad)
 {

--- a/contracts/PortfolioLib.sol
+++ b/contracts/PortfolioLib.sol
@@ -100,8 +100,8 @@ struct PortfolioCurve {
 }
 
 struct PortfolioPool {
-    uint128 virtualX; // WAD x per WAD liquidity.
-    uint128 virtualY; // WAD y per WAD liquidity.
+    uint128 virtualX; // Total X reserves in WAD units for all liquidity.
+    uint128 virtualY; // Total Y reserves in WAD units for all liquidity.
     uint128 liquidity; // Total supply of liquidity.
     uint32 lastTimestamp; // The block.timestamp of the last swap.
     address controller; // Address that can change fee, priorityFee, or jit params.
@@ -110,40 +110,40 @@ struct PortfolioPool {
 }
 
 struct PortfolioPosition {
-    uint128 freeLiquidity;
-    uint32 lastTimestamp;
+    uint128 freeLiquidity; // Liquidity owned by the position owner in WAD units.
+    uint32 lastTimestamp; // The block.timestamp of the last position update.
 }
 
 struct ChangeLiquidityParams {
     address owner;
     uint64 poolId;
     uint256 timestamp;
-    uint256 deltaAsset;
-    uint256 deltaQuote;
-    address tokenAsset;
-    address tokenQuote;
-    int128 deltaLiquidity;
+    uint256 deltaAsset; // Quantity of asset tokens in WAD units to add or remove.
+    uint256 deltaQuote; // Quantity of quote tokens in WAD units to add or remove.
+    address tokenAsset; // Address of the asset token.
+    address tokenQuote; // Address of the quote token.
+    int128 deltaLiquidity; // Quantity of liquidity tokens in WAD units to add or remove.
 }
 
 struct Order {
-    uint8 useMax;
+    uint8 useMax; // Use the transiently stored `balance` for the `input`.
     uint64 poolId;
-    uint128 input;
-    uint128 output;
-    uint8 sellAsset;
+    uint128 input; // Quantity of asset tokens in WAD units to swap in, adding to reserves.
+    uint128 output; // Quantity of quote tokens in WAD units to swap out, removing from reserves.
+    uint8 sellAsset; // 0 = quote -> asset, 1 = asset -> quote.
 }
 
 struct Iteration {
-    int256 prevInvariant; // WAD
-    int256 nextInvariant; // WAD
-    uint256 virtualX; // WAD
-    uint256 virtualY; // WAD
-    uint256 remainder; // WAD
-    uint256 feeAmount; // WAD
+    int256 prevInvariant; // Invariant of the pool before the swap, after timestamp update.
+    int256 nextInvariant; // Invariant of the pool after the swap.
+    uint256 virtualX; // Virtual X reserves in WAD units for all liquidity.
+    uint256 virtualY; // Virtual Y reserves in WAD units for all liquidity.
+    uint256 remainder; // Remainder of input tokens to swap in, in WAD units.
+    uint256 feeAmount; // Fee amount in WAD units.
     uint256 protocolFeeAmount; // WAD
-    uint256 liquidity; // WAD
-    uint256 input; // DEC -> WAD -> DEC
-    uint256 output; // DEC -> WAD -> DEC
+    uint256 liquidity; // Total supply of liquidity in WAD units.
+    uint256 input;
+    uint256 output;
 }
 
 struct SwapState {
@@ -155,8 +155,9 @@ struct SwapState {
 
 struct Payment {
     address token;
-    uint256 amount;
-    uint256 balance;
+    uint256 amountTransferTo; // Amount to transfer to the `msg.sender` in `settlement`, in WAD.
+    uint256 amountTransferFrom; // Amount to transfer from the `msg.sender` in `settlement`, in WAD.
+    uint256 balance; // Current `token.balanceOf(address(this))` in `settlement`, in native token decimals.
 }
 
 // ===== Effects ===== //
@@ -194,7 +195,9 @@ function changePositionLiquidity(
 // ===== View ===== //
 
 /**
- * @dev Quantity of tokens in units of their native decimals deallocated if all liquidity was removed.
+ * @dev Quantity of tokens in WAD units if all liquidity was removed.
+ * @return reserveAsset Real `asset` tokens removed from pool, denominated in WAD.
+ * @return reserveQuote Real `quote` tokens removed from pool, denominated in WAD.
  */
 function getPoolReserves(PortfolioPool memory self)
     pure
@@ -207,17 +210,14 @@ function getPoolReserves(PortfolioPool memory self)
 
 /**
  * @dev Maximum amount of liquidity minted given amounts of each token.
- * @param deltaAsset Quantity of `asset` tokens denominated in their native decimals.
- * @param deltaQuote Quantity of `quote` tokens denominated in their native decimals.
+ * @param deltaAsset Up to quantity of `asset` tokens used to mint liquidity, denominated in WAD.
+ * @param deltaQuote Up to quantity of `quote` tokens used to mint liquidity, denominated in WAD.
  */
 function getPoolMaxLiquidity(
     PortfolioPool memory self,
     uint256 deltaAsset,
     uint256 deltaQuote
 ) pure returns (uint128 deltaLiquidity) {
-    deltaAsset = deltaAsset.scaleToWad(self.pair.decimalsAsset).safeCastTo128();
-    deltaQuote = deltaQuote.scaleToWad(self.pair.decimalsQuote).safeCastTo128();
-
     uint256 totalLiquidity = self.liquidity;
     if (totalLiquidity == 0) totalLiquidity = INIT_LIQUIDITY; // use 1E18 of liquidity
 
@@ -230,46 +230,47 @@ function getPoolMaxLiquidity(
 
 /**
  * @dev Rounds positive deltas up. Rounds negative deltas down.
+ * @return deltaAsset Real `asset` tokens underlying `deltaLiquidity`, denominated in WAD.
+ * @return deltaQuote Real `quote` tokens underlying `deltaLiquidity`, denominated in WAD.
  */
 function getPoolLiquidityDeltas(
     PortfolioPool memory self,
     int128 deltaLiquidity
 ) pure returns (uint128 deltaAsset, uint128 deltaQuote) {
     if (deltaLiquidity == 0) return (deltaAsset, deltaQuote);
-    uint256 delta =
-        deltaLiquidity > 0 ? uint128(deltaLiquidity) : uint128(-deltaLiquidity);
 
+    uint256 delta;
+    uint256 totalLiquidity = self.liquidity;
     (uint256 amountAssetWad, uint256 amountQuoteWad) =
         self.getVirtualReservesWad();
 
     // Pre-allocate pools initialize reserves to 1E18 of liquidity to
     // compute the first allocate quantities.
     if (self.liquidity == 0) {
-        uint256 scaleDownFactorAsset = AssemblyLib.computeScalar(
-            self.pair.decimalsAsset
-        ) * FixedPointMathLib.WAD;
-        uint256 scaleDownFactorQuote = AssemblyLib.computeScalar(
-            self.pair.decimalsQuote
-        ) * FixedPointMathLib.WAD;
-
-        amountAssetWad = delta.mulDivUp(amountAssetWad, scaleDownFactorAsset);
-        amountQuoteWad = delta.mulDivUp(amountQuoteWad, scaleDownFactorQuote);
-        return (amountAssetWad.safeCastTo128(), amountQuoteWad.safeCastTo128());
+        totalLiquidity = 1e18;
     }
 
-    amountAssetWad = delta.mulDivUp(amountAssetWad, self.liquidity);
-    amountQuoteWad = delta.mulDivUp(amountQuoteWad, self.liquidity);
-
-    (deltaAsset, deltaQuote) = (
-        amountAssetWad.scaleFromWadDown(self.pair.decimalsAsset).safeCastTo128(),
-        amountQuoteWad.scaleFromWadDown(self.pair.decimalsQuote).safeCastTo128()
-    );
+    if (deltaLiquidity > 0) {
+        // If allocating liquidity, round token amounts up.
+        delta = uint128(deltaLiquidity);
+        deltaAsset =
+            delta.mulDivUp(amountAssetWad, totalLiquidity).safeCastTo128();
+        deltaQuote =
+            delta.mulDivUp(amountQuoteWad, totalLiquidity).safeCastTo128();
+    } else {
+        // If deallocating liquidity, round token amounts down.
+        delta = uint128(-deltaLiquidity);
+        deltaAsset =
+            delta.mulDivDown(amountAssetWad, totalLiquidity).safeCastTo128();
+        deltaQuote =
+            delta.mulDivDown(amountQuoteWad, totalLiquidity).safeCastTo128();
+    }
 }
 
 /**
  * @dev Scales virtual reserves from WAD to native token decimal units.
- * @return amountAssetDec Quantity of `asset` tokens in native decimal units.
- * @return amountQuoteDec Quantity of `quote` tokens in native decimal units.
+ * @return amountAssetDec Virtual `asset` tokens tracked, scaled to native decimal units.
+ * @return amountQuoteDec Virtual `quote` tokens tracked, scaled to native decimal units.
  */
 function getVirtualReservesDec(PortfolioPool memory self)
     pure
@@ -285,8 +286,8 @@ function getVirtualReservesDec(PortfolioPool memory self)
 
 /**
  * @dev Virtual reserves of tokens in WAD units.
- * @return amountAssetWad Quantity of `asset` tokens in WAD units.
- * @return amountQuoteWad Quantity of `quote` tokens in WAD units.
+ * @return amountAssetWad Virtual `asset` tokens tracked, in WAD units.
+ * @return amountQuoteWad Virtual `quote` tokens tracked, in WAD units.
  */
 function getVirtualReservesWad(PortfolioPool memory self)
     pure

--- a/contracts/RMM01Portfolio.sol
+++ b/contracts/RMM01Portfolio.sol
@@ -29,7 +29,10 @@ contract RMM01Portfolio is PortfolioVirtual {
      * movement.
      * @custom:reverts Underflows if current reserves of output token is less then next reserves.
      */
-    function _getLatestInvariantAndVirtualPrice(uint64 poolId)
+    function _getLatestInvariantAndVirtualPrice(
+        uint64 poolId,
+        bool sellAsset
+    )
         internal
         view
         returns (uint256 price, int256 invariant, uint256 updatedTau)
@@ -37,8 +40,23 @@ contract RMM01Portfolio is PortfolioVirtual {
         PortfolioPool storage pool = pools[poolId];
         updatedTau = pool.computeTau(block.timestamp);
 
-        uint256 reserveXPerLiquidity = pool.virtualX.divWadDown(pool.liquidity);
-        uint256 reserveYPerLiquidity = pool.virtualY.divWadDown(pool.liquidity);
+        uint256 reserveXPerLiquidity = pool.virtualX;
+        uint256 reserveYPerLiquidity = pool.virtualY;
+
+        // The reserve which sends tokens out in this swap must be rounded up
+        // to avoid the scenario that the remainder in a truncated output amount
+        // is not stolen in the swap.
+        if (sellAsset) {
+            // Swap X -> Y, Y is output, so round up Y.
+            reserveXPerLiquidity =
+                reserveXPerLiquidity.divWadDown(pool.liquidity);
+            reserveYPerLiquidity = reserveYPerLiquidity.divWadUp(pool.liquidity);
+        } else {
+            // Swap Y -> X, X is output, so round up X.
+            reserveXPerLiquidity = reserveXPerLiquidity.divWadUp(pool.liquidity);
+            reserveYPerLiquidity =
+                reserveYPerLiquidity.divWadDown(pool.liquidity);
+        }
 
         invariant = int128(
             pool.invariantOf({
@@ -57,12 +75,12 @@ contract RMM01Portfolio is PortfolioVirtual {
     }
 
     /// @inheritdoc Objective
-    function _beforeSwapEffects(uint64 poolId)
-        internal
-        override
-        returns (bool, int256)
-    {
-        (, int256 invariant,) = _getLatestInvariantAndVirtualPrice(poolId);
+    function _beforeSwapEffects(
+        uint64 poolId,
+        bool sellAsset
+    ) internal override returns (bool, int256) {
+        (, int256 invariant,) =
+            _getLatestInvariantAndVirtualPrice(poolId, sellAsset);
         pools[poolId].syncPoolTimestamp(block.timestamp);
 
         // Buffer for post-maturity swaps would go here.
@@ -168,6 +186,6 @@ contract RMM01Portfolio is PortfolioVirtual {
         override
         returns (uint256 price)
     {
-        (price,,) = _getLatestInvariantAndVirtualPrice(poolId);
+        (price,,) = _getLatestInvariantAndVirtualPrice(poolId, true);
     }
 }

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -263,11 +263,11 @@ interface IPortfolioGetters {
         returns (uint256 deltaAsset, uint256 deltaQuote);
 
     /**
-     * @dev Amount of tokens in native token decimals per WAD liquidity.
+     * @dev Amount of tokens in native token decimals.
      * @return deltaAsset Quantity of `asset` tokens in wad units.
      * @return deltaQuote Quantity of `quote` tokens in wad units.
      */
-    function getVirtualReservesPerLiquidity(uint64 poolId)
+    function getVirtualReservesDec(uint64 poolId)
         external
         view
         returns (uint128 deltaAsset, uint128 deltaQuote);

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -131,8 +131,8 @@ interface IPortfolioEvents {
 interface IPortfolioGetters {
     // ===== Account Getters ===== //
     /**
-     * @dev Internally owned balance of `token` of `owner`.
-     * @return Balance held, in native `token` decimal units.
+     * @dev Transiently owned internal balance of `token` of `owner`.
+     * @return Balance held in WAD units.
      */
     function getBalance(
         address owner,
@@ -141,14 +141,15 @@ interface IPortfolioGetters {
 
     /**
      * @dev Internally tracked global balance of all `token`s assigned to an address or a pool.
-     * @return Global balance held, in native `token` decimal units.
+     * @return Global balance held in WAD units.
      */
     function getReserve(address token) external view returns (uint256);
 
     /**
      * @notice Difference of `token.balanceOf(this)` and internally tracked reserve balance.
      * @dev Critical system invariant. Must always return greater than or equal to zero.
-     * @custom:example
+     * @return Net balance held in WAD units.
+     * @custom:example Assumes token is 18 decimals.
      * ```
      * uint256 previousReserve = getReserve(token);
      * uint256 previousBalance = token.balanceOf(portfolio);
@@ -233,6 +234,8 @@ interface IPortfolioGetters {
     /**
      * @dev Computes amount of `deltaAsset` and `deltaQuote` that must be paid for to
      * mint `deltaLiquidity`.
+     * @return deltaAsset Real quantity of `asset` tokens underlying `deltaLiquidity`, in native decimal units.
+     * @return deltaQuote Real quantity of `quote` tokens underlying `deltaLiquidity`, in native decimal units.
      */
     function getLiquidityDeltas(
         uint64 poolId,
@@ -264,8 +267,8 @@ interface IPortfolioGetters {
 
     /**
      * @dev Amount of tokens in native token decimals.
-     * @return deltaAsset Quantity of `asset` tokens in wad units.
-     * @return deltaQuote Quantity of `quote` tokens in wad units.
+     * @return deltaAsset Quantity of `asset` tokens in native decimal units.
+     * @return deltaQuote Quantity of `quote` tokens in native decimal units.
      */
     function getVirtualReservesDec(uint64 poolId)
         external

--- a/contracts/libraries/AccountLib.sol
+++ b/contracts/libraries/AccountLib.sol
@@ -215,15 +215,16 @@ function cache(AccountSystem storage self, address token, bool status) {
 
 /**
  * @dev Computes surplus (positive) or deficit (negative) in actual tokens compared to tracked amounts.
+ * @return net Net balance of physical - virtual tokens in native token decimals.
  */
 function getNetBalance(
     AccountSystem storage self,
     address token,
     address account
 ) view returns (int256 net) {
-    uint256 internalBalance = self.reserves[token];
+    uint256 internalBalanceWad = self.reserves[token];
+    uint256 internalBalance =
+        AssemblyLib.scaleFromWadUp(internalBalanceWad, IERC20(token).decimals());
     uint256 physicalBalance = __balanceOf__(token, account);
-    uint256 physicalBalanceWad =
-        AssemblyLib.scaleToWad(physicalBalance, IERC20(token).decimals());
-    net = int256(physicalBalanceWad) - int256(internalBalance);
+    net = int256(physicalBalance) - int256(internalBalance);
 }

--- a/contracts/libraries/AccountLib.sol
+++ b/contracts/libraries/AccountLib.sol
@@ -173,10 +173,8 @@ function settle(
 ) returns (uint256 credited, uint256 debited, uint256 remainder) {
     int256 net = self.getNetBalance(token, account);
     if (net > 0) {
+        // Token remaining in internal balance or untracked tokens to transfer out.
         credited = uint256(net);
-        // unaccounted for tokens, e.g. transferred directly into Portfolio.
-        self.credit(msg.sender, token, uint256(net)); // gift to `msg.sender`.
-        self.reserves[token] += uint256(net); // add the difference back to reserves, so net is zero.
     } else if (net < 0) {
         // missing tokens that must be paid for or transferred in.
         remainder = uint256(-net);
@@ -225,5 +223,7 @@ function getNetBalance(
 ) view returns (int256 net) {
     uint256 internalBalance = self.reserves[token];
     uint256 physicalBalance = __balanceOf__(token, account);
-    net = int256(physicalBalance) - int256(internalBalance);
+    uint256 physicalBalanceWad =
+        AssemblyLib.scaleToWad(physicalBalance, IERC20(token).decimals());
+    net = int256(physicalBalanceWad) - int256(internalBalance);
 }

--- a/contracts/libraries/AssemblyLib.sol
+++ b/contracts/libraries/AssemblyLib.sol
@@ -303,6 +303,16 @@ library AssemblyLib {
         }
     }
 
+    function scaleFromWadUp(
+        uint256 amountWad,
+        uint256 decimals
+    ) internal pure returns (uint256 outputDec) {
+        if (amountWad == 0) return 0;
+
+        uint256 factor = computeScalar(decimals);
+        outputDec = (amountWad - 1) / factor + 1; // ((a-1) / b) + 1
+    }
+
     /*
 
     /!\ Do not use this function, it's completely cursed:

--- a/contracts/libraries/RMM01Lib.sol
+++ b/contracts/libraries/RMM01Lib.sol
@@ -103,12 +103,19 @@ library RMM01Lib {
         data.liquidity = self.liquidity;
         (data.virtualX, data.virtualY) = self.getVirtualReservesWad();
         tau = self.computeTau(timestamp);
-        data.prevInvariant = invariantOf({
-            self: self,
-            R_x: data.virtualX.divWadDown(data.liquidity),
-            R_y: data.virtualY.divWadDown(data.liquidity),
-            timeRemainingSec: tau
-        });
+
+        uint256 R_x;
+        uint256 R_y;
+        if (sellAsset) {
+            R_x = data.virtualX.divWadDown(data.liquidity);
+            R_y = data.virtualY.divWadUp(data.liquidity);
+        } else {
+            R_x = data.virtualX.divWadUp(data.liquidity);
+            R_y = data.virtualY.divWadDown(data.liquidity);
+        }
+
+        data.prevInvariant =
+            invariantOf({self: self, R_x: R_x, R_y: R_y, timeRemainingSec: tau});
         data.remainder = amountIn.scaleToWad(
             sellAsset ? self.pair.decimalsAsset : self.pair.decimalsQuote
         );

--- a/contracts/libraries/RMM01Lib.sol
+++ b/contracts/libraries/RMM01Lib.sol
@@ -72,12 +72,12 @@ library RMM01Lib {
 
         // Uses data.invariant, data.liquidity, and data.remainder to compute next input reserve.
         // Uses next input reserve to compute output reserve.
-        (uint256 prevDep, uint256 nextDep) =
+        (uint256 prevDepTotalWad, uint256 nextDepTotalWad) =
             computeSwapStep(self, data, sellAsset, tau);
 
         // Checks to make sure next reserve decreases and computes the difference in WAD.
-        if (nextDep > prevDep) revert SwapInputTooSmall();
-        data.output += (prevDep - nextDep).mulWadDown(data.liquidity);
+        if (nextDepTotalWad > prevDepTotalWad) revert SwapInputTooSmall();
+        data.output += prevDepTotalWad - nextDepTotalWad;
 
         // Scale down amounts from WAD.
         uint256 outputDec =
@@ -100,19 +100,18 @@ library RMM01Lib {
             ? self.params.priorityFee
             : self.params.fee;
 
-        (data.virtualX, data.virtualY) =
-            self.getVirtualPoolReservesPerLiquidityInWad();
+        data.liquidity = self.liquidity;
+        (data.virtualX, data.virtualY) = self.getVirtualReservesWad();
         tau = self.computeTau(timestamp);
         data.prevInvariant = invariantOf({
             self: self,
-            R_x: data.virtualX,
-            R_y: data.virtualY,
+            R_x: data.virtualX.divWadDown(data.liquidity),
+            R_y: data.virtualY.divWadDown(data.liquidity),
             timeRemainingSec: tau
         });
         data.remainder = amountIn.scaleToWad(
             sellAsset ? self.pair.decimalsAsset : self.pair.decimalsQuote
         );
-        data.liquidity = self.liquidity;
         data.feeAmount = (data.remainder * fee) / PERCENTAGE;
 
         return (data, tau);
@@ -128,37 +127,45 @@ library RMM01Lib {
         uint256 tau
     ) internal pure returns (uint256 prevDep, uint256 nextDep) {
         uint256 prevInd;
-        uint256 nextInd;
+        uint256 nextIndWadPerLiquidity;
+        uint256 nextDepWadPerLiquidity;
         uint256 volatilityWad = convertPercentageToWad(self.params.volatility);
 
-        // if sellAsset, ind = x && dep = y, else ind = y && dep = x
+        // If sellAsset, ind = x && dep = y, else ind = y && dep = x
+        // These are the total reserves of tokens in the pool scaled to WAD decimals.
         if (sellAsset) {
             (prevInd, prevDep) = (data.virtualX, data.virtualY);
         } else {
             (prevDep, prevInd) = (data.virtualX, data.virtualY);
         }
 
-        nextInd = prevInd
-            + (data.remainder - data.feeAmount).divWadDown(data.liquidity);
+        uint256 deltaInLessFee = data.remainder - data.feeAmount;
+        nextIndWadPerLiquidity = prevInd + deltaInLessFee;
+        nextIndWadPerLiquidity =
+            nextIndWadPerLiquidity.divWadDown(data.liquidity);
 
         // Compute the output of the swap by computing the difference between the dependent reserves.
+        // Uses the next independent reserve in WAD units per 1 WAD of liquidity.
         if (sellAsset) {
-            nextDep = Invariant.getY({
-                R_x: nextInd,
+            nextDepWadPerLiquidity = Invariant.getY({
+                R_x: nextIndWadPerLiquidity,
                 stk: self.params.maxPrice,
                 vol: volatilityWad,
                 tau: tau,
                 inv: data.prevInvariant
             });
         } else {
-            nextDep = Invariant.getX({
-                R_y: nextInd,
+            nextDepWadPerLiquidity = Invariant.getX({
+                R_y: nextIndWadPerLiquidity,
                 stk: self.params.maxPrice,
                 vol: volatilityWad,
                 tau: tau,
                 inv: data.prevInvariant
             });
         }
+
+        // Scales the next dependent per liquidity to total dependent reserves, in WAD units.
+        nextDep = nextDepWadPerLiquidity.mulWadDown(data.liquidity);
     }
 
     /**
@@ -193,7 +200,7 @@ library RMM01Lib {
     // ===== Raw Functions ===== //
 
     /**
-     * @dev Used in `getVirtualPoolReservesPerLiquidityInWad` to compute the virtual amount of assets at the self's price.
+     * @dev Used in `getVirtualReservesWad` to compute the virtual amount of assets at the self's price.
      * @param prc WAD
      * @param stk WAD
      * @param vol percentage

--- a/echidna/GlobalInvariants.sol
+++ b/echidna/GlobalInvariants.sol
@@ -250,7 +250,7 @@ contract GlobalInvariants is
     }
 
     function pool_get_amounts_wad_returns_safe_bounds() public {
-        // The `getVirtualPoolReservesPerLiquidityInWad` method always returns less than `1e18` for `amountAssetWad` and `pool.params.strike()` for `amountQuoteWad`.
+        // The `getVirtualReservesWad` method always returns less than `1e18` for `amountAssetWad` and `pool.params.strike()` for `amountQuoteWad`.
 
         for (uint8 i = 0; i < poolIds.length; i++) {
             uint64 poolId = poolIds[i];
@@ -258,7 +258,7 @@ contract GlobalInvariants is
             PortfolioCurve memory curve = pool.params;
 
             (uint256 amountAssetWad, uint256 amountQuoteWad) =
-                pool.getVirtualPoolReservesPerLiquidityInWad();
+                pool.getVirtualReservesWad();
 
             if (amountAssetWad > 1e18) {
                 emit LogUint256("amountAssetWad", amountAssetWad);
@@ -275,7 +275,7 @@ contract GlobalInvariants is
     }
 
     function pool_get_amounts_returns_less_than_get_amounts_wad() public {
-        // The `getAmounts` method always returns values less than or equal to `getVirtualPoolReservesPerLiquidityInWad`.
+        // The `getAmounts` method always returns values less than or equal to `getVirtualReservesWad`.
 
         for (uint8 i = 0; i < poolIds.length; i++) {
             uint64 poolId = poolIds[i];
@@ -285,14 +285,14 @@ contract GlobalInvariants is
                 pool.getPoolAmountsPerLiquidity();
 
             (uint256 amountAssetWad, uint256 amountQuoteWad) =
-                pool.getVirtualPoolReservesPerLiquidityInWad();
+                pool.getVirtualReservesWad();
 
             // Assumes inclusivity of bounds (i.e: equivalence is okay)
             if (amountAssetDec > amountAssetWad) {
                 emit LogUint256("amountAssetDec", amountAssetDec);
                 emit LogUint256("amountAssetWad", amountAssetWad);
                 emit AssertionFailed(
-                    "BUG (asset): getAmounts returned more than getVirtualPoolReservesPerLiquidityInWad"
+                    "BUG (asset): getAmounts returned more than getVirtualReservesWad"
                     );
             }
             // Assumes inclusivity of bounds (i.e: equivalence is okay)
@@ -300,7 +300,7 @@ contract GlobalInvariants is
                 emit LogUint256("amountQuoteDec", amountQuoteDec);
                 emit LogUint256("amountQuoteWad", amountQuoteWad);
                 emit AssertionFailed(
-                    "BUG (quote): getAmounts returned more than getVirtualPoolReservesPerLiquidityInWad"
+                    "BUG (quote): getAmounts returned more than getVirtualReservesWad"
                     );
             }
         }

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -895,14 +895,15 @@ contract TestGas is Setup {
         _subject.fund(token, 1 ether);
     }
 
-    function test_gas_draw() public pauseGas useActor {
+    // todo: Cannot carry internal balances over between transactions, its only transient.
+    /* function test_gas_draw() public pauseGas useActor {
         (address token,) = _getTokens();
         Coin.wrap(token).prepare(actor(), address(subject()), 1 ether);
 
         _subject.fund(token, 1 ether);
         vm.resumeGasMetering();
         _subject.draw(token, 1 ether, actor());
-    }
+    } */
 
     function test_gas_chain_allocate_deallocate_from_portfolio_balance()
         public

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import "./Setup.sol";
+import "contracts/PortfolioLib.sol";
 
 contract TestGas is Setup {
     using SafeCastLib for uint256;
@@ -55,7 +56,7 @@ contract TestGas is Setup {
         usePools(1)
         useActor
         usePairTokens(10 ether)
-        allocateSome(1 ether)
+        allocateSome(1 ether + uint128(BURNED_LIQUIDITY))
         isArmed
     {
         bytes memory data = FVM.encodeAllocateOrDeallocate(
@@ -264,7 +265,7 @@ contract TestGas is Setup {
                     true,
                     uint8(0),
                     poolId,
-                    1 ether,
+                    1 ether + uint128(BURNED_LIQUIDITY),
                     type(uint128).max,
                     type(uint128).max
                 )
@@ -586,7 +587,7 @@ contract TestGas is Setup {
                 true,
                 uint8(0),
                 poolId,
-                1 ether,
+                1 ether + uint128(BURNED_LIQUIDITY),
                 type(uint128).max,
                 type(uint128).max
             );
@@ -912,6 +913,7 @@ contract TestGas is Setup {
         usePools(1)
         useActor
         usePairTokens(10 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         subject().fund(ghost().asset().to_addr(), type(uint256).max);
@@ -933,6 +935,7 @@ contract TestGas is Setup {
         usePools(1)
         useActor
         usePairTokens(10 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         bytes[] memory instructions = new bytes[](2);

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.4;
 import "./Setup.sol";
 
 contract TestPortfolioAllocate is Setup {
+    using AssemblyLib for uint256;
+
     function test_allocate_modifies_liquidity()
         public
         defaultConfig
@@ -40,7 +42,8 @@ contract TestPortfolioAllocate is Setup {
         );
     }
 
-    function test_allocate_use_max()
+    // todo: Use max now only uses entire transient balances, which need to be increased from a swap output or deallocatye.
+    /* function test_allocate_use_max()
         public
         defaultConfig
         useActor
@@ -66,7 +69,7 @@ contract TestPortfolioAllocate is Setup {
             ghost().position(actor()).freeLiquidity,
             "position.freeLiquidity != pool.liquidity"
         );
-    }
+    } */
 
     function test_allocate_does_not_modify_timestamp()
         public
@@ -480,6 +483,11 @@ contract TestPortfolioAllocate is Setup {
             ghost().reserve(ghost().asset().to_addr()),
             ghost().reserve(ghost().quote().to_addr())
         );
+
+        postR_A =
+            postR_A.scaleFromWadDown(ghost().asset().to_token().decimals());
+        postR_Q =
+            postR_Q.scaleFromWadDown(ghost().quote().to_token().decimals());
 
         assertEq(postA, expectedA, "pool asset balance");
         assertEq(postQ, expectedQ, "pool quote balance");

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -36,7 +36,7 @@ contract TestPortfolioAllocate is Setup {
         assertEq(post, prev + amount, "pool.liquidity");
         // Direct assertions of pool state.
         assertEq(
-            ghost().pool().liquidity,
+            ghost().pool().liquidity - BURNED_LIQUIDITY,
             ghost().position(actor()).freeLiquidity,
             "position.freeLiquidity != pool.liquidity"
         );
@@ -363,6 +363,7 @@ contract TestPortfolioAllocate is Setup {
         sixDecimalQuoteConfig
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -377,6 +378,7 @@ contract TestPortfolioAllocate is Setup {
         durationConfig(uint16(bound(duration, MIN_DURATION, MAX_DURATION)))
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -391,6 +393,7 @@ contract TestPortfolioAllocate is Setup {
         durationConfig(uint16(bound(duration, MIN_DURATION, MIN_DURATION + 100)))
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -405,6 +408,7 @@ contract TestPortfolioAllocate is Setup {
         durationConfig(uint16(bound(duration, MAX_DURATION - 100, MAX_DURATION)))
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -419,6 +423,7 @@ contract TestPortfolioAllocate is Setup {
         volatilityConfig(uint16(bound(volatility, MIN_VOLATILITY, MAX_VOLATILITY)))
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -435,6 +440,7 @@ contract TestPortfolioAllocate is Setup {
         )
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -451,6 +457,7 @@ contract TestPortfolioAllocate is Setup {
         )
         useActor
         usePairTokens(500 ether)
+        allocateSome(uint128(BURNED_LIQUIDITY))
         isArmed
     {
         vm.assume(liquidity > 0);
@@ -462,6 +469,11 @@ contract TestPortfolioAllocate is Setup {
         (uint128 expectedA, uint128 expectedQ) =
             subject().getLiquidityDeltas(ghost().poolId, int128(amount));
         uint256 prev = ghost().pool().liquidity;
+        (uint256 prevA, uint256 prevQ) = (
+            ghost().asset().to_token().balanceOf(address(subject())),
+            ghost().quote().to_token().balanceOf(address(subject()))
+        );
+
         subject().multiprocess(
             FVMLib.encodeAllocateOrDeallocate({
                 shouldAllocate: true,
@@ -489,13 +501,13 @@ contract TestPortfolioAllocate is Setup {
         postR_Q =
             postR_Q.scaleFromWadDown(ghost().quote().to_token().decimals());
 
-        assertEq(postA, expectedA, "pool asset balance");
-        assertEq(postQ, expectedQ, "pool quote balance");
+        assertEq(postA, prevA + expectedA, "pool asset balance");
+        assertEq(postQ, prevQ + expectedQ, "pool quote balance");
         assertEq(postR_A, postA, "pool asset reserve");
         assertEq(postR_Q, postQ, "pool quote reserve");
         assertEq(post, prev + amount, "pool.liquidity");
         assertEq(
-            ghost().pool().liquidity,
+            ghost().pool().liquidity - BURNED_LIQUIDITY,
             ghost().position(actor()).freeLiquidity,
             "position.freeLiquidity != pool.liquidity"
         );

--- a/test/TestPortfolioDeposit.t.sol
+++ b/test/TestPortfolioDeposit.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 import "./Setup.sol";
 
 contract TestPortfolioDeposit is Setup {
-    function test_deposit_increases_user_weth_balance() public useActor {
+/* function test_deposit_increases_user_weth_balance() public useActor {
         uint256 amount = 10 ether;
         uint256 prev = ghost().balance(actor(), subject().WETH());
         subject().deposit{value: amount}();
@@ -39,5 +39,5 @@ contract TestPortfolioDeposit is Setup {
         uint256 amount = 10 ether;
         subject().deposit{value: amount}();
         assertEq(address(subject().WETH()).balance, amount, "zero-balance");
-    }
+    } */
 }

--- a/test/TestPortfolioDraw.t.sol
+++ b/test/TestPortfolioDraw.t.sol
@@ -10,7 +10,7 @@ contract TestPortfolioDraw is Setup {
         _;
     }
 
-    function test_draw_reduces_user_balance()
+    /* function test_draw_reduces_user_balance()
         public
         defaultConfig
         useActor
@@ -22,7 +22,7 @@ contract TestPortfolioDraw is Setup {
         uint256 post = ghost().balance(address(this), ghost().asset().to_addr());
         assertTrue(post < prev, "non-decreasing-balance");
         assertEq(post, prev - 1 ether, "post-balance");
-    }
+    } */
 
     function test_revert_draw_greater_than_balance()
         public
@@ -35,7 +35,7 @@ contract TestPortfolioDraw is Setup {
         subject().draw(tkn, 1 ether, address(this));
     }
 
-    function test_draw_weth_transfers_ether() public useActor {
+    /*  function test_draw_weth_transfers_ether() public useActor {
         uint256 amt = 1 ether;
         subject().deposit{value: amt}();
         uint256 prev = address(this).balance;
@@ -43,9 +43,9 @@ contract TestPortfolioDraw is Setup {
         uint256 post = address(this).balance;
         assertEq(post, prev + amt, "post-balance");
         assertTrue(post > prev, "draw-did-not-increase-balance");
-    }
+    } */
 
-    function test_draw_max_balance()
+    /* function test_draw_max_balance()
         public
         defaultConfig
         useActor
@@ -58,5 +58,5 @@ contract TestPortfolioDraw is Setup {
         );
         uint256 post = ghost().balance(address(this), ghost().asset().to_addr());
         assertEq(post, prev - 1 ether, "did-not-draw-max");
-    }
+    } */
 }

--- a/test/TestPortfolioFund.t.sol
+++ b/test/TestPortfolioFund.t.sol
@@ -11,7 +11,7 @@ contract TestPortfolioFund is Setup {
         uint256 subjectActualBalance;
     }
 
-    function test_fund_increases_user_balance() public defaultConfig isArmed {
+    /* function test_fund_increases_user_balance() public defaultConfig isArmed {
         uint256 amt = 1 ether;
         address tkn = ghost().asset().to_addr();
         ghost().asset().prepare(address(this), address(subject()), amt);
@@ -19,9 +19,9 @@ contract TestPortfolioFund is Setup {
         subject().fund(tkn, amt);
         uint256 post = ghost().balance(address(this), tkn);
         assertEq(post, prev + amt, "did-not-increase-balance");
-    }
+    } */
 
-    function test_fund_max_balance() public defaultConfig isArmed {
+    /* function test_fund_max_balance() public defaultConfig isArmed {
         uint256 amt = 10 ether;
         address tkn = ghost().asset().to_addr();
         ghost().asset().prepare(address(this), address(subject()), amt);
@@ -29,9 +29,9 @@ contract TestPortfolioFund is Setup {
         subject().fund(tkn, amt);
         uint256 post = ghost().balance(address(this), tkn);
         assertEq(post, prev + amt, "did-not-increase-balance");
-    }
+    } */
 
-    function testFuzz_fund_then_draw(uint64 amt) public defaultConfig isArmed {
+    /* function testFuzz_fund_then_draw(uint64 amt) public defaultConfig isArmed {
         vm.assume(amt > 0);
 
         // Prepare the token and give this contract a balanc and approve subject().
@@ -124,5 +124,5 @@ contract TestPortfolioFund is Setup {
             ghost_state_prev.subjectActualBalance,
             "subj-actual-balance-final"
         );
-    }
+    } */
 }

--- a/test/TestPortfolioSwap.t.sol
+++ b/test/TestPortfolioSwap.t.sol
@@ -21,7 +21,7 @@ contract TestPortfolioSwap is Setup {
             )
         );
 
-        uint256 prev = ghost().balance(address(this), ghost().quote().to_addr());
+        uint256 prev = ghost().quote().to_token().balanceOf(actor());
         subject().multiprocess(
             FVMLib.encodeSwap(
                 uint8(0),
@@ -31,7 +31,7 @@ contract TestPortfolioSwap is Setup {
                 uint8(sellAsset ? 1 : 0)
             )
         );
-        uint256 post = ghost().balance(address(this), ghost().quote().to_addr());
+        uint256 post = ghost().quote().to_token().balanceOf(actor());
 
         assertTrue(post > prev, "balance-did-not-increase");
     }
@@ -47,12 +47,10 @@ contract TestPortfolioSwap is Setup {
         bool sellAsset = true;
         uint128 amtIn = 0.1 ether;
         uint128 amtOut = uint128(
-            subject().getAmountOut(
-                ghost().poolId, sellAsset, amtIn, address(this)
-            )
+            subject().getAmountOut(ghost().poolId, sellAsset, amtIn, actor())
         );
 
-        uint256 prev = ghost().balance(address(this), ghost().quote().to_addr());
+        uint256 prev = ghost().quote().to_token().balanceOf(actor());
 
         vm.warp(
             block.timestamp
@@ -67,9 +65,9 @@ contract TestPortfolioSwap is Setup {
                 uint8(sellAsset ? 1 : 0)
             )
         );
-        uint256 post = ghost().balance(address(this), ghost().quote().to_addr());
+        uint256 post = ghost().quote().to_token().balanceOf(actor());
 
-        assertTrue(post > prev, "balance-did-not-increase");
+        assertTrue(post > prev, "physical-balance-did-not-increase");
     }
 
     function test_swap_protocol_fee()

--- a/test/invariant/HandlerPortfolio.sol
+++ b/test/invariant/HandlerPortfolio.sol
@@ -6,6 +6,7 @@ import "solmate/utils/SafeCastLib.sol";
 
 contract HandlerPortfolio is HandlerBase {
     using SafeCastLib for uint256;
+    using AssemblyLib for uint256;
 
     function callSummary() external view {
         console.log("deposit", calls["deposit"]);
@@ -553,6 +554,14 @@ contract HandlerPortfolio is HandlerBase {
         // TODO: Breaks when we call this function on a pool with zero liquidity...
         (uint256 dAsset, uint256 dQuote) =
             ctx.subject().getPoolReserves(ctx.ghost().poolId);
+        emit log("dAssetWad", dAsset);
+        emit log("dQuoteWad", dQuote);
+
+        dAsset =
+            dAsset.scaleFromWadDown(ctx.ghost().asset().to_token().decimals());
+        dQuote =
+            dQuote.scaleFromWadDown(ctx.ghost().quote().to_token().decimals());
+
         emit log("dAsset", dAsset);
         emit log("dQuote", dQuote);
 
@@ -569,8 +578,12 @@ contract HandlerPortfolio is HandlerBase {
         emit log("diffAsset", diffAsset);
         emit log("diffQuote", diffQuote);
 
-        assertTrue(bAsset >= dAsset, "invariant-virtual-reserves-asset");
-        assertTrue(bQuote >= dQuote, "invariant-virtual-reserves-quote");
+        assertTrue(
+            bAsset >= dAsset, "invariant-virtual-reserves-asset-check-invariant"
+        );
+        assertTrue(
+            bQuote >= dQuote, "invariant-virtual-reserves-quote-check-invariant"
+        );
 
         emit FinishedCall("Check Virtual Invariant");
     }

--- a/test/invariant/HandlerPortfolio.sol
+++ b/test/invariant/HandlerPortfolio.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import "./setup/HandlerBase.sol";
+import "contracts/PortfolioLib.sol";
 import "solmate/utils/SafeCastLib.sol";
 
 contract HandlerPortfolio is HandlerBase {
@@ -419,7 +420,7 @@ contract HandlerPortfolio is HandlerBase {
         assertEq(deltaQuote, expectedDeltaQuote, "pool-delta-quote");
         assertEq(
             post.totalPoolLiquidity,
-            prev.totalPoolLiquidity + deltaLiquidity,
+            prev.totalPoolLiquidity + deltaLiquidity - BURNED_LIQUIDITY,
             "pool-total-liquidity"
         );
         assertTrue(
@@ -428,7 +429,7 @@ contract HandlerPortfolio is HandlerBase {
         );
         assertEq(
             post.callerPositionLiquidity,
-            prev.callerPositionLiquidity + deltaLiquidity,
+            prev.callerPositionLiquidity + deltaLiquidity - BURNED_LIQUIDITY,
             "position-liquidity-increases"
         );
 

--- a/test/invariant/TestRMM01PortfolioInvariants.t.sol
+++ b/test/invariant/TestRMM01PortfolioInvariants.t.sol
@@ -24,9 +24,11 @@ interface AccountLike {
  * pools.
  */
 contract TestRMM01PortfolioInvariants is Setup {
+    using AssemblyLib for uint256;
     /**
      * @dev Helper to manage the pools that are being interacted with via the handlers.
      */
+
     InvariantGhostState private _ghostInvariant;
 
     HandlerPortfolio internal _portfolio;
@@ -76,12 +78,16 @@ contract TestRMM01PortfolioInvariants is Setup {
     function invariant_asset_balance_gte_reserves() public {
         (uint256 reserve, uint256 physical,) =
             getBalances(ghost().asset().to_addr());
+        reserve =
+            reserve.scaleFromWadDown(ghost().asset().to_token().decimals());
         assertTrue(physical >= reserve, "invariant-asset-physical-balance");
     }
 
     function invariant_quote_balance_gte_reserves() public {
         (uint256 reserve, uint256 physical,) =
             getBalances(ghost().quote().to_addr());
+        reserve =
+            reserve.scaleFromWadDown(ghost().quote().to_token().decimals());
         assertTrue(physical >= reserve, "invariant-quote-physical-balance");
     }
 
@@ -96,6 +102,8 @@ contract TestRMM01PortfolioInvariants is Setup {
         if (pool.liquidity > 0) {
             (uint256 dAsset,) = subject().getPoolReserves(ghost().poolId);
             uint256 bAsset = ghost().physicalBalance(ghost().asset().to_addr());
+            dAsset =
+                dAsset.scaleFromWadDown(ghost().asset().to_token().decimals());
             assertTrue(bAsset >= dAsset, "invariant-virtual-reserves-asset");
         }
     }
@@ -106,6 +114,8 @@ contract TestRMM01PortfolioInvariants is Setup {
         if (pool.liquidity > 0) {
             (, uint256 dQuote) = subject().getPoolReserves(ghost().poolId);
             uint256 bQuote = ghost().physicalBalance(ghost().quote().to_addr());
+            dQuote =
+                dQuote.scaleFromWadDown(ghost().quote().to_token().decimals());
             assertTrue(bQuote >= dQuote, "invariant-virtual-reserves-quote");
         }
     }


### PR DESCRIPTION
# Description
Accepts token amounts in native decimals as parameters and returns values in native token decimals. Handles all internal logic with WAD values. Changes virtual reserves to track total pool reserves in WAD, instead of WAD per liquidity. Changes global reserves to be in WAD units instead of native token decimals. Major changes to `settlement` to transfer extra credited tokens out to `msg.sender` via `transfer`, instead of applying the credits to the internal user balance.

See https://github.com/primitivefinance/portfolio/pull/338 to see the extended changes after these are made. I made them separate PRs since they are large.

# Changes summarized:
- Scales DEC -> WAD in `_process`.
- Changes `reserves` from DEC -> WAD
- Changes `balances` from DEC -> WAD
- Changes `virtualX/Y` from WAD / Liq -> WAD / Total Liq
- Updates `_changeLiquidity` to increase/decrease `virtualX/Y` by equal amounts to increase/decrease `reserves`.
- Scales WAD -> DEC at end of operation, before event is emitted, e.g. allocate, deallocate, swap.
- Updates `AccountLib.settle` by removing the `self.credit` call in the branch which credited > 0.
- Updates `AccountLib.settle` by removing the increase to `reserves` call in the branch which credited > 0.
- Updates `AccountLib.getNetBalance` by scaling the `balanceOf` (physical balance) token amounts from native DEC -> WAD, then computing the difference and returning it in WAD units.
- Updates `Payment` struct and changes `amount` -> `amountToTransferFrom`, and adds `amountToTransfer`.
- Updates `settlement` by removing events emitted in branch case credited > 0.
- Updates `settlement` by doing the external call `transfer` for all extra tokens in the branch case credited > 0.
- Updates `settlement` with handling the transferFrom/transfer calls along with the balance verification within a single loop instead of a third loop.
- Comments some now invalid unit tests for deposit/fund/draw.
- Updates natspec to reflect changes to either WAD or DEC units for parameters and return values.

Notes
- getNetBalance computation is weird, because you can have a negative balance from having a fractional amount of tokens since it's scaled up?
- View functions and external arguments provided by users are expected to be in native decimal units, they are converted within the functions.
- Balances cannot be held between transactions since the extra credits are always transferred out in `settlement`.
- It's possible to transfer tokens in after they have been settled, if transferred in via one of the other settlement external calls `transfer` or `transferFrom`. Implications: extra tokens can be in physical reserves after settlement, which could be claimed by another caller in follow up transactions? Other than that, unknown.
- Protocol fee logic needs to be re-reviewed, so far it looks like its fine to apply the credit to the REGISTRY address. The logic works but it's really confusing basically:
  - Total input amount in swap from user
  - subtract some fee for protocol
  - apply that amount to credit of REGISTRY
  - Increase total global reserves by the total input amount
  - Increase the pool reserves by the input amount - protocol fee
  - conclusion: the small difference in total global reserve and pool reserves is the credit that is given to the registry.