### PR TITLE
Fix/deallocate before swap

### DIFF
--- a/contracts/Objective.sol
+++ b/contracts/Objective.sol
@@ -82,6 +82,7 @@ abstract contract Objective is IPortfolio {
         uint64 poolId,
         bool sellAsset,
         uint256 amountIn,
+        int256 liquidityDelta,
         address swapper
     )
         public

--- a/contracts/RMM01Portfolio.sol
+++ b/contracts/RMM01Portfolio.sol
@@ -162,12 +162,14 @@ contract RMM01Portfolio is PortfolioVirtual {
         uint64 poolId,
         bool sellAsset,
         uint256 amountIn,
+        int256 liquidityDelta,
         address swapper
     ) public view override(Objective) returns (uint256 output) {
         PortfolioPool memory pool = pools[poolId];
         output = pool.getAmountOut({
             sellAsset: sellAsset,
             amountIn: amountIn,
+            liquidityDelta: liquidityDelta,
             timestamp: block.timestamp,
             swapper: swapper
         });

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -287,6 +287,7 @@ interface IPortfolioGetters {
         uint64 poolId,
         bool sellAsset,
         uint256 amountIn,
+        int256 liquidityDelta,
         address swapper
     ) external view returns (uint256);
 

--- a/contracts/libraries/RMM01Lib.sol
+++ b/contracts/libraries/RMM01Lib.sol
@@ -63,12 +63,14 @@ library RMM01Lib {
         PortfolioPool memory self,
         bool sellAsset,
         uint256 amountIn,
+        int256 liquidityDelta,
         uint256 timestamp,
         address swapper
     ) internal pure returns (uint256 amountOut) {
         // Sets data.invariant, data.liquidity, and data.remainder.
-        (Iteration memory data, uint256 tau) =
-            getSwapData(self, sellAsset, amountIn, timestamp, swapper); // Declare and assign variables individual to save on gas spent on initializing 0 values.
+        (Iteration memory data, uint256 tau) = getSwapData(
+            self, sellAsset, amountIn, liquidityDelta, timestamp, swapper
+        ); // Declare and assign variables individual to save on gas spent on initializing 0 values.
 
         // Uses data.invariant, data.liquidity, and data.remainder to compute next input reserve.
         // Uses next input reserve to compute output reserve.
@@ -92,6 +94,7 @@ library RMM01Lib {
         PortfolioPool memory self,
         bool sellAsset,
         uint256 amountIn,
+        int256 liquidityDelta,
         uint256 timestamp,
         address swapper
     ) internal pure returns (Iteration memory, uint256 tau) {
@@ -100,7 +103,10 @@ library RMM01Lib {
             ? self.params.priorityFee
             : self.params.fee;
 
-        data.liquidity = self.liquidity;
+        data.liquidity = liquidityDelta > 0
+            ? self.liquidity + uint256(liquidityDelta)
+            : self.liquidity - uint256(-liquidityDelta);
+
         (data.virtualX, data.virtualY) = self.getVirtualReservesWad();
         tau = self.computeTau(timestamp);
 
@@ -114,8 +120,12 @@ library RMM01Lib {
             R_y = data.virtualY.divWadDown(data.liquidity);
         }
 
-        data.prevInvariant =
-            invariantOf({self: self, R_x: R_x, R_y: R_y, timeRemainingSec: tau});
+        data.prevInvariant = invariantOf({
+            self: self,
+            R_x: R_x,
+            R_y: R_y,
+            timeRemainingSec: tau
+        });
         data.remainder = amountIn.scaleToWad(
             sellAsset ? self.pair.decimalsAsset : self.pair.decimalsQuote
         );

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -292,7 +292,7 @@ contract Setup is Test {
 
     modifier swapSome(uint128 amt, bool sellAsset) {
         uint128 amtOut = subject().getAmountOut(
-            ghost().poolId, sellAsset, amt, address(this)
+            ghost().poolId, sellAsset, amt, 0, address(this)
         ).safeCastTo128();
 
         Order memory order = Order({
@@ -311,7 +311,7 @@ contract Setup is Test {
 
     modifier swapSomeGetOut(uint128 amt, int256 amtOutDelta, bool sellAsset) {
         uint128 amtOut = subject().getAmountOut(
-            ghost().poolId, sellAsset, amt, address(this)
+            ghost().poolId, sellAsset, amt, 0, address(this)
         ).safeCastTo128();
         amtOut = amtOutDelta > 0
             ? amtOut + uint256(amtOutDelta).safeCastTo128()

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -81,8 +81,9 @@ contract TestGas is Setup {
         bool sellAsset = true;
         uint128 amountIn = uint128(0.01 ether);
         uint128 estimatedAmountOut = uint128(
-            _subject.getAmountOut(ghost().poolId, sellAsset, amountIn, actor())
-                * 95 / 100
+            _subject.getAmountOut(
+                ghost().poolId, sellAsset, amountIn, 0, actor()
+            ) * 95 / 100
         );
         bytes[] memory data = new bytes[](1);
 
@@ -623,8 +624,8 @@ contract TestGas is Setup {
                     .liquidity
             }).safeCastTo128() / 10;
             uint128 estimatedAmountOut = uint128(
-                _subject.getAmountOut(poolId, sellAsset, amountIn, actor()) * 95
-                    / 100
+                _subject.getAmountOut(poolId, sellAsset, amountIn, 0, actor())
+                    * 95 / 100
             );
 
             Order memory order = Order({
@@ -677,7 +678,7 @@ contract TestGas is Setup {
     ) internal returns (bytes memory) {
         uint128 amountIn = uint128(0.05 ether);
         uint128 amountOut = subject().getAmountOut(
-            poolId, direction, amountIn, actor()
+            poolId, direction, amountIn, 0, actor()
         ).safeCastTo128();
 
         Order memory order = Order({

--- a/test/TestPortfolioSwap.t.sol
+++ b/test/TestPortfolioSwap.t.sol
@@ -24,7 +24,7 @@ contract TestPortfolioSwap is Setup {
         uint128 amtIn = 0.1 ether;
         uint128 amtOut = uint128(
             subject().getAmountOut(
-                ghost().poolId, sellAsset, amtIn, address(this)
+                ghost().poolId, sellAsset, amtIn, 0, address(this)
             )
         );
 
@@ -57,7 +57,7 @@ contract TestPortfolioSwap is Setup {
         bool sellAsset = true;
         uint128 amtIn = 0.1 ether;
         uint128 amtOut = uint128(
-            subject().getAmountOut(ghost().poolId, sellAsset, amtIn, actor())
+            subject().getAmountOut(ghost().poolId, sellAsset, amtIn, 0, actor())
         );
 
         uint256 prev = ghost().quote().to_token().balanceOf(actor());
@@ -99,7 +99,7 @@ contract TestPortfolioSwap is Setup {
         uint128 amtIn = 0.1 ether;
         uint128 amtOut = uint128(
             subject().getAmountOut(
-                ghost().poolId, sellAsset, amtIn, address(this)
+                ghost().poolId, sellAsset, amtIn, 0, address(this)
             )
         );
 
@@ -380,7 +380,7 @@ contract TestPortfolioSwap is Setup {
         }
 
         uint128 amountOut = subject().getAmountOut(
-            ghost().poolId, sellAsset, amountIn, actor()
+            ghost().poolId, sellAsset, amountIn, 0, actor()
         ).safeCastTo128();
 
         // todo: fix getAmountOut to be accurate
@@ -436,8 +436,9 @@ contract TestPortfolioSwap is Setup {
     {
         bool sellAsset = true;
         uint256 amountIn = 0.01 ether;
-        uint256 amountOut =
-            subject().getAmountOut(ghost().poolId, sellAsset, amountIn, actor());
+        uint256 amountOut = subject().getAmountOut(
+            ghost().poolId, sellAsset, amountIn, 0, actor()
+        );
 
         _swap_assert_price(sellAsset, amountIn, amountOut);
     }
@@ -452,8 +453,9 @@ contract TestPortfolioSwap is Setup {
     {
         bool sellAsset = false;
         uint256 amountIn = 0.01 ether;
-        uint256 amountOut =
-            subject().getAmountOut(ghost().poolId, sellAsset, amountIn, actor());
+        uint256 amountOut = subject().getAmountOut(
+            ghost().poolId, sellAsset, amountIn, 0, actor()
+        );
 
         _swap_assert_price(sellAsset, amountIn, amountOut);
     }
@@ -470,8 +472,9 @@ contract TestPortfolioSwap is Setup {
         uint256 amountIn = uint256(0.01 ether).scaleFromWadDown(
             ghost().asset().to_token().decimals()
         );
-        uint256 amountOut =
-            subject().getAmountOut(ghost().poolId, sellAsset, amountIn, actor());
+        uint256 amountOut = subject().getAmountOut(
+            ghost().poolId, sellAsset, amountIn, 0, actor()
+        );
 
         _swap_assert_price(sellAsset, amountIn, amountOut);
     }
@@ -488,8 +491,9 @@ contract TestPortfolioSwap is Setup {
         uint256 amountIn = uint256(0.01 ether).scaleFromWadDown(
             ghost().quote().to_token().decimals()
         );
-        uint256 amountOut =
-            subject().getAmountOut(ghost().poolId, sellAsset, amountIn, actor());
+        uint256 amountOut = subject().getAmountOut(
+            ghost().poolId, sellAsset, amountIn, 0, actor()
+        );
 
         _swap_assert_price(sellAsset, amountIn, amountOut);
     }
@@ -608,8 +612,9 @@ contract TestPortfolioSwap is Setup {
         );
         vm.assume(maxIn > amountIn);
 
-        uint256 amountOut =
-            subject().getAmountOut(ghost().poolId, sellAsset, amountIn, actor());
+        uint256 amountOut = subject().getAmountOut(
+            ghost().poolId, sellAsset, amountIn, 0, actor()
+        );
 
         _swap_check_invariant(
             sellAsset, amountIn, amountOut, reserveXPerL, reserveYPerL


### PR DESCRIPTION
Fixes https://github.com/primitivefinance/portfolio/issues/301 by adding an extra parameter `liquidityDelta` to `getAmountOut`. This means that this function can now be used to predict the required parameters of a swap that will happen after a change of liquidity in a pool.