### PR TITLE
Create3 factory and deployment script

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 	path = lib/solstat
 	url = https://github.com/primitivefinance/solstat
 	branch = main
+[submodule "lib/create3-factory"]
+	path = lib/create3-factory
+	url = https://github.com/zeframlou/create3-factory

--- a/scripts/Create3Factory.sol
+++ b/scripts/Create3Factory.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "solmate/utils/CREATE3.sol";
+
+contract Create3Factory {
+    function deploy(
+        bytes32 salt,
+        bytes memory creationCode
+    ) external payable returns (address deployed) {
+        salt = keccak256(abi.encodePacked(msg.sender, salt));
+        return CREATE3.deploy(salt, creationCode, msg.value);
+    }
+
+    function getDeployed(
+        address deployer,
+        bytes32 salt
+    ) external view returns (address deployed) {
+        salt = keccak256(abi.encodePacked(deployer, salt));
+        return CREATE3.getDeployed(salt);
+    }
+}

--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -3,12 +3,16 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
 import "solmate/tokens/WETH.sol";
+import "create3-factory/src/ICREATE3Factory.sol";
+
 import "contracts/RMM01Portfolio.sol";
 import "contracts/test/SimpleRegistry.sol";
 
 contract Deploy is Script {
     // Set address if deploying on a network with an existing weth.
     address public __weth__; //= 0x575E4246f36a92bd88bcAAaEE2c51499B64116Ed;
+
+    bytes32 salt = keccak256(abi.encode("cheese"));
 
     event Deployed(
         address owner, address weth, address portfolio, address registry
@@ -21,8 +25,18 @@ contract Deploy is Script {
         address weth = __weth__;
         if (weth == address(0)) weth = address(new WETH());
 
-        address registry = address(new SimpleRegistry());
-        address portfolio = address(new RMM01Portfolio(weth, registry));
+        ICREATE3Factory factory =
+            ICREATE3Factory(0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf);
+
+        address registry =
+            factory.deploy(salt, type(SimpleRegistry).creationCode);
+
+        address portfolio = factory.deploy(
+            salt,
+            abi.encodePacked(
+                type(RMM01Portfolio).creationCode, abi.encode(weth, registry)
+            )
+        );
 
         emit Deployed(msg.sender, weth, portfolio, registry);
 

--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
 import "solmate/tokens/WETH.sol";
-import "create3-factory/src/ICREATE3Factory.sol";
 
+import "./Create3Factory.sol";
 import "contracts/RMM01Portfolio.sol";
 import "contracts/test/SimpleRegistry.sol";
 
@@ -25,8 +25,7 @@ contract Deploy is Script {
         address weth = __weth__;
         if (weth == address(0)) weth = address(new WETH());
 
-        ICREATE3Factory factory =
-            ICREATE3Factory(0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf);
+        Create3Factory factory = new Create3Factory();
 
         address registry =
             factory.deploy(salt, type(SimpleRegistry).creationCode);
@@ -40,6 +39,7 @@ contract Deploy is Script {
 
         emit Deployed(msg.sender, weth, portfolio, registry);
 
+        console.log("Factory:", address(factory));
         console.log("WETH:", weth);
         console.log("Portfolio:", portfolio);
         console.log("Registry:", registry);


### PR DESCRIPTION
Adds a new deployment script based on a `create3` factory that will help us have the same contract addresses on all the different networks.

Before merging this, we need to investigate the deployment error of the `RMM01Portfolio` contract. The issue seems related to the size of the bytecode, even if the right compiler settings are provided.