### PR TITLE
Feat/fork safe transfer lib

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -864,7 +864,7 @@ abstract contract PortfolioVirtual is Objective {
                     );
                 } else {
                     Account.SafeTransferLib.safeTransfer(
-                        Account.ERC20(token), msg.sender, amountTransferTo
+                        token, msg.sender, amountTransferTo
                     );
                 }
 
@@ -879,8 +879,8 @@ abstract contract PortfolioVirtual is Objective {
                 uint256 prev = payments[index].balance;
 
                 // Interaction
-                Account.__dangerousTransferFrom__(
-                    token, address(this), amountTransferFrom
+                Account.SafeTransferLib.safeTransferFrom(
+                    token, msg.sender, address(this), amountTransferFrom
                 );
 
                 uint256 post = Account.__balanceOf__(token, address(this));

--- a/contracts/libraries/SafeTransferLib.sol
+++ b/contracts/libraries/SafeTransferLib.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+error EtherTransfer();
+error TokenTransferFrom();
+error TokenTransfer();
+
+/// @notice Safe ETH and ERC20 transfer library that gracefully handles missing return values.
+/// @dev Caution! This library won't check that a token has code, responsibility is delegated to the caller.
+/// @author Solmate (https://github.com/Rari-Capital/solmate/blob/main/src/utils/SafeTransferLib.sol)
+library SafeTransferLib {
+    /*//////////////////////////////////////////////////////////////
+                             ETH OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function safeTransferETH(address to, uint256 amount) internal {
+        bool success;
+
+        assembly {
+            // Transfer the ETH and store if it succeeded or not.
+            success := call(gas(), to, amount, 0, 0, 0, 0)
+        }
+
+        if (!success) revert EtherTransfer();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            ERC20 OPERATIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function safeTransferFrom(
+        address token,
+        address from,
+        address to,
+        uint256 amount
+    ) internal {
+        bool success;
+
+        assembly {
+            // We'll write our calldata to this slot below, but restore it later.
+            let memPointer := mload(0x40)
+
+            // Write the abi-encoded calldata into memory, beginning with the function selector.
+            mstore(
+                0,
+                0x23b872dd00000000000000000000000000000000000000000000000000000000
+            )
+            mstore(4, from) // Append the "from" argument.
+            mstore(36, to) // Append the "to" argument.
+            mstore(68, amount) // Append the "amount" argument.
+
+            success :=
+                and(
+                    // Set success to whether the call reverted, if not we check it either
+                    // returned exactly 1 (can't just be non-zero data), or had no return data.
+                    or(
+                        and(eq(mload(0), 1), gt(returndatasize(), 31)),
+                        iszero(returndatasize())
+                    ),
+                    // We use 100 because that's the total length of our calldata (4 + 32 * 3)
+                    // Counterintuitively, this call() must be positioned after the or() in the
+                    // surrounding and() because and() evaluates its arguments from right to left.
+                    call(gas(), token, 0, 0, 100, 0, 32)
+                )
+
+            mstore(0x60, 0) // Restore the zero slot to zero.
+            mstore(0x40, memPointer) // Restore the memPointer.
+        }
+
+        if (!success) revert TokenTransferFrom();
+    }
+
+    function safeTransfer(address token, address to, uint256 amount) internal {
+        bool success;
+
+        assembly {
+            // We'll write our calldata to this slot below, but restore it later.
+            let memPointer := mload(0x40)
+
+            // Write the abi-encoded calldata into memory, beginning with the function selector.
+            mstore(
+                0,
+                0xa9059cbb00000000000000000000000000000000000000000000000000000000
+            )
+            mstore(4, to) // Append the "to" argument.
+            mstore(36, amount) // Append the "amount" argument.
+
+            success :=
+                and(
+                    // Set success to whether the call reverted, if not we check it either
+                    // returned exactly 1 (can't just be non-zero data), or had no return data.
+                    or(
+                        and(eq(mload(0), 1), gt(returndatasize(), 31)),
+                        iszero(returndatasize())
+                    ),
+                    // We use 68 because that's the total length of our calldata (4 + 32 * 2)
+                    // Counterintuitively, this call() must be positioned after the or() in the
+                    // surrounding and() because and() evaluates its arguments from right to left.
+                    call(gas(), token, 0, 0, 68, 0, 32)
+                )
+
+            mstore(0x60, 0) // Restore the zero slot to zero.
+            mstore(0x40, memPointer) // Restore the memPointer.
+        }
+
+        if (!success) revert TokenTransfer();
+    }
+}


### PR DESCRIPTION
I forked Solmate SafeTransferLib to get turn all the `require` in favor of custom revert errors, it helped us go down to 22.89 KB for the `RMM01Portfolio` contract.