### PR TITLE
Feat/allocate recipient

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -205,6 +205,7 @@ abstract contract PortfolioVirtual is Objective {
     /// @inheritdoc IPortfolioActions
     function allocate(
         bool useMax,
+        address recipient,
         uint64 poolId,
         uint128 deltaLiquidity,
         uint128 maxDeltaAsset,
@@ -246,7 +247,7 @@ abstract contract PortfolioVirtual is Objective {
         }
 
         ChangeLiquidityParams memory args = ChangeLiquidityParams({
-            owner: msg.sender,
+            owner: recipient,
             poolId: poolId,
             timestamp: block.timestamp,
             deltaAsset: deltaAsset,

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -335,6 +335,7 @@ interface IPortfolioActions {
      */
     function allocate(
         bool useMax,
+        address recipient,
         uint64 poolId,
         uint128 deltaLiquidity,
         uint128 maxDeltaAsset,

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -290,7 +290,14 @@ contract Setup is Test {
         bytes[] memory data = new bytes[](1);
         data[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, ghost().poolId, amt, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                ghost().poolId,
+                amt,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(data);
         _;

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -43,6 +43,7 @@ contract TestGas is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 1 ether,
                 type(uint128).max,
@@ -146,7 +147,14 @@ contract TestGas is Setup {
 
             instructions[i] = abi.encodeCall(
                 IPortfolioActions.allocate,
-                (false, poolId, 1 ether, type(uint128).max, type(uint128).max)
+                (
+                    false,
+                    address(this),
+                    poolId,
+                    1 ether,
+                    type(uint128).max,
+                    type(uint128).max
+                )
             );
         }
 
@@ -267,6 +275,7 @@ contract TestGas is Setup {
                 IPortfolioActions.allocate,
                 (
                     false,
+                    address(this),
                     poolId,
                     1 ether + uint128(BURNED_LIQUIDITY),
                     type(uint128).max,
@@ -566,6 +575,7 @@ contract TestGas is Setup {
                 IPortfolioActions.allocate,
                 (
                     false,
+                    address(this),
                     poolId,
                     1 ether + uint128(BURNED_LIQUIDITY),
                     type(uint128).max,
@@ -668,12 +678,19 @@ contract TestGas is Setup {
 
     function _allocateInstruction(uint64 poolId)
         internal
-        pure
+        view
         returns (bytes memory)
     {
         return abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, poolId, 1 ether, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                poolId,
+                1 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
     }
 
@@ -760,7 +777,14 @@ contract TestGas is Setup {
             bytes[] memory actions = new bytes[](1);
             actions[0] = abi.encodeCall(
                 IPortfolioActions.allocate,
-                (false, poolId, 10 ether, type(uint128).max, type(uint128).max)
+                (
+                    false,
+                    address(this),
+                    poolId,
+                    10 ether,
+                    type(uint128).max,
+                    type(uint128).max
+                )
             );
             subject().multicall(actions);
         }
@@ -789,7 +813,14 @@ contract TestGas is Setup {
             bytes[] memory actions = new bytes[](1);
             actions[0] = abi.encodeCall(
                 IPortfolioActions.allocate,
-                (false, poolId, 25 ether, type(uint128).max, type(uint128).max)
+                (
+                    false,
+                    address(this),
+                    poolId,
+                    25 ether,
+                    type(uint128).max,
+                    type(uint128).max
+                )
             );
             subject().multicall(actions);
         }

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -72,6 +72,48 @@ contract TestPortfolioAllocate is Setup {
         subject().multicall{ value: 250 ether }(data);
     }
 
+    function test_allocate_recipient_weth()
+        public
+        wethConfig
+        useActor
+        usePairTokens(500 ether)
+        isArmed
+    {
+        vm.deal(actor(), 250 ether);
+
+        subject().allocate{ value: 250 ether }(
+            false,
+            address(0xbeef),
+            ghost().poolId,
+            1 ether,
+            type(uint128).max,
+            type(uint128).max
+        );
+
+        assertEq(ghost().position(address(this)), 0);
+        assertEq(ghost().position(address(0xbeef)), 1 ether - BURNED_LIQUIDITY);
+    }
+
+    function test_allocate_recipient_tokens()
+        public
+        defaultConfig
+        useActor
+        usePairTokens(10 ether)
+        isArmed
+    {
+        subject().allocate(
+            false,
+            address(0xbeef),
+            ghost().poolId,
+            1 ether,
+            type(uint128).max,
+            type(uint128).max
+        );
+
+        assertEq(ghost().position(address(this)), 0);
+        assertEq(ghost().position(address(0xbeef)), 1 ether - BURNED_LIQUIDITY);
+    }
+
     function test_allocate_multicall_modifies_liquidity()
         public
         defaultConfig

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -30,7 +30,14 @@ contract TestPortfolioAllocate is Setup {
 
         data[2] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, poolId, 1 ether, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                poolId,
+                1 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
 
         subject().multicall(data);
@@ -54,6 +61,7 @@ contract TestPortfolioAllocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 1 ether,
                 type(uint128).max,
@@ -82,7 +90,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -114,7 +129,12 @@ contract TestPortfolioAllocate is Setup {
         // Trigger the function being tested.
 
         subject().allocate(
-            false, xid, amount, type(uint128).max, type(uint128).max
+            false,
+            address(this),
+            xid,
+            amount,
+            type(uint128).max,
+            type(uint128).max
         );
 
         // Fetch the variable changed.
@@ -173,7 +193,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -200,7 +227,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -228,7 +262,7 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, 0, type(uint128).max)
+            (false, address(this), xid, amount, 0, type(uint128).max)
         );
         subject().multicall(instructions);
     }
@@ -248,7 +282,7 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, 0)
+            (false, address(this), xid, amount, type(uint128).max, 0)
         );
         subject().multicall(instructions);
     }
@@ -275,7 +309,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -309,7 +350,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -333,7 +381,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, failureArg, 1 ether, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                failureArg,
+                1 ether,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
     }
@@ -352,6 +407,7 @@ contract TestPortfolioAllocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 uint128(failureArg),
                 type(uint128).max,
@@ -375,6 +431,7 @@ contract TestPortfolioAllocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 uint128(failureArg),
                 type(uint128).max,
@@ -410,7 +467,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 
@@ -539,7 +603,14 @@ contract TestPortfolioAllocate is Setup {
         bytes[] memory instructions = new bytes[](1);
         instructions[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(instructions);
 

--- a/test/TestPortfolioDeallocate.t.sol
+++ b/test/TestPortfolioDeallocate.t.sol
@@ -19,6 +19,7 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
@@ -58,6 +59,7 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
@@ -85,6 +87,7 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
@@ -112,6 +115,7 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
@@ -137,13 +141,14 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
                 type(uint128).max
             )
         );
-        subject().multicall{value: 250 ether}(data);
+        subject().multicall{ value: 250 ether }(data);
         _simple_deallocate(liquidity);
     }
 
@@ -164,6 +169,7 @@ contract TestPortfolioDeallocate is Setup {
             IPortfolioActions.allocate,
             (
                 false,
+                address(this),
                 ghost().poolId,
                 liquidity,
                 type(uint128).max,
@@ -188,7 +194,14 @@ contract TestPortfolioDeallocate is Setup {
         bytes[] memory data = new bytes[](1);
         data[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(data);
         vm.expectRevert();
@@ -213,13 +226,20 @@ contract TestPortfolioDeallocate is Setup {
         bytes[] memory data = new bytes[](1);
         data[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, xid, amount, type(uint128).max, type(uint128).max)
+            (
+                false,
+                address(this),
+                xid,
+                amount,
+                type(uint128).max,
+                type(uint128).max
+            )
         );
         subject().multicall(data);
 
         data[0] = abi.encodeCall(
             IPortfolioActions.allocate,
-            (false, ghost().poolId, amount, 0, type(uint128).max)
+            (false, address(this), ghost().poolId, amount, 0, type(uint128).max)
         );
         vm.expectRevert();
         subject().multicall(data);

--- a/test/invariant/HandlerPortfolio.sol
+++ b/test/invariant/HandlerPortfolio.sol
@@ -257,6 +257,7 @@ contract HandlerPortfolio is HandlerBase {
                 IPortfolioActions.allocate,
                 (
                     false,
+                    address(this),
                     ctx.ghost().poolId,
                     deltaLiquidity.safeCastTo128(),
                     type(uint128).max,


### PR DESCRIPTION
A small change to the `allocate` function that adds a `recipient` parameter. This could be useful for contracts moving funds on the behalf of their users (for example to migrate liquidity).