### PR TITLE
Audit/spearbit july

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -112,27 +112,75 @@ contract Portfolio is ERC1155, IPortfolio {
     uint64 private _getLastPoolId;
 
     /**
+     * @notice
+     * Custom mutex designed to prevent injected single-call re-entrancy
+     * during multi-calls.
+     *
      * @dev
-     * Protects against reentrancy and getting to invalid settlement states.
+     * Protects against re-entrancy and getting to invalid settlement states.
      * This lock works in pair with `_postLock` and both should be used on all
      * external non-view functions (except the restricted ones).
+     *
+     * Upon entering the mutex, there can be two conditions:
+     * 1. `_locked != 1`. If not in a multicall, i.e. `&& !_currentMulticall`,
+     *                    revert (singleCall -> singleCall re-entrancy).
+     * 2. `_locked > 2`.  Reached here from starting in multicall.
+     *                    This was called from another singleCall that did not have postLock() fire,
+     *                    i.e. `_locked > 2`, revert because its injected re-entrancy:
+     *                    (multiCall -> singleCall -> injected singleCall re-entrancy).
+     *
+     * This enforces that only the originally defined multicall actions are run,
+     * and injected single calls are successfully caught and reverted by the mutex.
+     * These injected re-entrancy guards are caught because the `postLock()` never gets called,
+     * which decrements the `_locked` variable.
+     * Multicalls go through because they don't fire the `postLock()` until after the calls ran.
+     *
+     * @custom:example Scenarios:
+     * 1. reenter during multicall's action execution
+     * multicall -> _currentMulticall = true
+     *   preLock() -> _locked++ = 2
+     *     singleCall()
+     *       preLock() -> _locked++ = 3
+     *       reenter during current execution (injected) -> postLock() does not decrement _locked.
+     *         singeCall()
+     *           preLock(): (_locked != 1 && (false || true)) == true, revert
+     *   _currentMulticall = false;
+     *   settlement()
+     *   postLock()
+     *
+     * 2. reenter during multicall's settlement
+     * multicall -> _currentMulticall = true
+     *   preLock() -> _locked++ = 2
+     *     singleCall
+     *       preLock(): -> _locked++ == 3
+     *       postLock(): -> _locked-- == 2
+     *   _currentMulticall = false;
+     *   settlement() -> _locked == 2
+     *     reenter
+     *       singeCall()
+     *         preLock(): (_locked != 1 && (true || false)) == true, revert
+     *   ...if continued (somehow gets passed the revert)
+     *       mutliCall()
+     *         passes multicall re-entrancy guard because not in multicall
+     *         preLock(): (_locked != 1 && (true || false)) == true, revert
+     *   ... settlement finishes
+     *   postLock(): -> _locked-- == 1
      *
      * note
      * Private functions are used instead of modifiers to reduce the size
      * of the bytecode.
      */
     function _preLock() private {
-        // Reverts if the lock was already set and the current call is not a multicall.
-        if (_locked != 1 && !_currentMulticall) {
+        if (_locked != 1 && (!_currentMulticall || _locked > 2)) {
             revert Portfolio_InvalidReentrancy();
         }
 
-        _locked = 2;
+        _locked++;
     }
 
     /// @dev Second part of the reentracy guard (see `_preLock`).
     function _postLock() private {
-        _locked = 1;
+        _locked--;
 
         // Reverts if the account system was not settled after a normal call.
         if (!__account__.settled && !_currentMulticall) {

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -571,7 +571,26 @@ interface IPortfolioActions is IPortfolioRegistryActions {
      * @notice
      * Instantiate a pool at a desired price with custom fees and arguments.
      *
+     * @dev
+     * WARNING: Pools can be created with __malicious__ `strategy` contracts.
+     * The `strategy` contracts have the power to create custom `swap` validation logic,
+     * and also can prevent the pool from being allocated to or deallocated from.
+     * Pools are created with a default strategy that uses standard mathematics based
+     * swap validation logic. Pools can never have their strategy changed after creation.
+     *
+     * Pools can have a `controller` address which has limited power over the pool.
+     * Pool controllers have the power to adjust the `feeBasisPoints` and `priorityFeeBasisPoints`.
+     * These can only be adjusted within reasonable bounds: the MIN and MAX fee bounds.
+     *
      * @param pairId Nonce of the target pair. A `0` is a magic variable to use the state variable `getPairNonce` instead.
+     * @param reserveXPerWad Initial virtual reserve for the `asset` token, per WAD units of liquidity and in WAD units.
+     * @param reserveYPerWad Initial virtual reserve for the `quote` token, per WAD units of liquidity and in WAD units.
+     * @param feeBasisPoints Fee charged on swaps, denominated in basis points (1 = 0.01%).
+     * @param priorityFeeBasisPoints Fee charged on swaps if the swap is initiated by the `controller`, denominated in basis points (1 = 0.01%).
+     * @param controller Address that can adjust the pool's fee and priority fee within reasonable bounds.
+     * @param strategy Address of the external strategy contract that handles swap validation.
+     * @param strategyArgs Abi-encoded arguments that are passed to the `strategy` contract via the `afterCreate` hook.
+     * @return poolId Packed encoded custom identifier for the pool. See `PoolLib.sol` for more details.
      */
     function createPool(
         uint24 pairId,

--- a/contracts/libraries/AssemblyLib.sol
+++ b/contracts/libraries/AssemblyLib.sol
@@ -138,34 +138,6 @@ library AssemblyLib {
         outputDec = (amountWad - 1) / factor + 1; // ((a-1) / b) + 1
     }
 
-    /**
-     * @dev
-     * Returns an encoded pool id given specific pool parameters.
-     * The encoding is simply packing the different parameters together.
-     *
-     * @custom:example
-     * ```
-     * uint64 poolId = encodePoolId(7, true, 42);
-     * assertEq(poolId, 0x000007010000002a);
-     * uint64 poolIdEncoded = abi.encodePacked(uint24(pairId), uint8(isMutable ? 1 : 0), uint32(poolNonce));
-     * assertEq(poolIdEncoded, poolId);
-     * ```
-     *
-     * @param pairId Id of the pair of asset / quote tokens
-     * @param isMutable True if the pool is mutable
-     * @param poolNonce Current pool nonce of the Portfolio contract
-     * @return poolId Corresponding encoded pool id
-     */
-    function encodePoolId(
-        uint24 pairId,
-        bool isMutable,
-        uint32 poolNonce
-    ) internal pure returns (uint64 poolId) {
-        assembly {
-            poolId := or(or(shl(40, pairId), shl(32, isMutable)), poolNonce)
-        }
-    }
-
     /// @dev Converts basis points (1 = 0.01%) to percentages in WAD units (1E18 = 100%).
     function bpsToPercentWad(uint256 bps)
         internal
@@ -182,5 +154,23 @@ library AssemblyLib {
         require(x < 1 << 16);
 
         y = uint16(x);
+    }
+
+    /// @dev Packs 4 bits into the upper and lower sections of a byte (8-bits).
+    function pack(
+        bytes1 upper,
+        bytes1 lower
+    ) internal pure returns (bytes1 data) {
+        data = upper << 4 | (lower & 0x0F);
+    }
+
+    /// @dev Separates the upper 4 and lower 4 bits of a byte (8-bits).
+    function separate(bytes1 data)
+        internal
+        pure
+        returns (bytes1 upper, bytes1 lower)
+    {
+        upper = data >> 4;
+        lower = data & 0x0f;
     }
 }

--- a/contracts/libraries/BisectionLib.sol
+++ b/contracts/libraries/BisectionLib.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.4;
 /// @dev Thrown when the lower bound is greater than the upper bound.
 error BisectionLib_InvalidBounds(uint256 lower, uint256 upper);
 /// @dev Thrown when the result of the function `fx` for each input, `upper` and `lower`, is the same sign.
-error BisectionLib_RootOutsideBounds(uint256 lower, uint256 upper);
+error BisectionLib_RootOutsideBounds(int256 lowerResult, int256 upperResult);
 
 /**
  * @notice
@@ -38,7 +38,7 @@ function bisection(
     int256 lowerOutput = fx(args, lower);
     int256 upperOutput = fx(args, upper);
     if (lowerOutput * upperOutput > 0) {
-        revert BisectionLib_RootOutsideBounds(lower, upper);
+        revert BisectionLib_RootOutsideBounds(lowerOutput, upperOutput);
     }
 
     // Distance is optimized to equal `epsilon`.

--- a/contracts/libraries/PoolLib.sol
+++ b/contracts/libraries/PoolLib.sol
@@ -33,24 +33,24 @@ library PoolIdLib {
      *
      * @custom:example
      * ```
-     * uint64 poolId = encode(true, true, 7,  42);
-     * assertEq(poolId, 0x110000070000002a);
-     * bool controlled = true;
      * bool altered = true;
-     * bytes1 packedBools = AssemblyLib.pack(bytes1(uint8(controlled ? 1 : 0)), bytes1(uint8(altered ? 1 : 0)));
+     * bool controlled = false;
+     * uint64 poolId = encode(altered, controlled, 7,  42);
+     * assertEq(poolId, 0x100000070000002a);
+     * bytes1 packedBools = AssemblyLib.pack(bytes1(uint8(altered ? 1 : 0)), bytes1(uint8(controlled ? 1 : 0)));
      * uint64 poolIdEncoded = abi.encodePacked(packedBools, uint24(pairId), uint32(poolNonce));
      * assertEq(poolIdEncoded, poolId);
      * ```
      *
-     * @param controlled Whether the pool has a non-zero address controller.
      * @param altered Whether the pool has the non-default strategy address.
+     * @param controlled Whether the pool has a non-zero address controller.
      * @param pairId Id of the pair of asset / quote tokens.
      * @param poolNonce Current pool nonce of the created pools for the `pairId`.
      * @return poolId Packs the above arguments into a 64-bit pool identifier.
      */
     function encode(
-        bool controlled,
         bool altered,
+        bool controlled,
         uint24 pairId,
         uint32 poolNonce
     ) internal pure returns (uint64 poolId) {

--- a/contracts/libraries/SwapLib.sol
+++ b/contracts/libraries/SwapLib.sol
@@ -14,7 +14,6 @@ using {
 using AssemblyLib for uint256;
 using FixedPointMathLib for uint128;
 
-error SwapLib_FeeTooHigh();
 error SwapLib_ProtocolFeeTooHigh();
 error SwapLib_OutputExceedsReserves();
 error SwapLib_ZeroXAdjustment();
@@ -116,7 +115,7 @@ function computeAdjustedSwapReserves(
     // Input amount is added to the reserves for the swap.
     adjustedInputReserveWad += self.input;
     // Fee amount is reinvested into the pool, but it's not considered in the invariant check, so we subtract it.
-    if (feeAmountUnit > adjustedInputReserveWad) revert SwapLib_FeeTooHigh();
+    // Assumes the fee % is always less than 100%, therefore this cannot underflow.
     adjustedInputReserveWad -= feeAmountUnit;
     // Protocol fee is subtracted, even though it's included in the fee, because protocol fees
     // do not get added to the pool's reserves.

--- a/contracts/strategies/NormalStrategy.sol
+++ b/contracts/strategies/NormalStrategy.sol
@@ -88,7 +88,7 @@ contract NormalStrategy is INormalStrategy {
             config: configs[poolId],
             order: Order({
                 input: 2, // avoid revert from zero adjustment, 2 for avoiding fee
-                output: 2, // avoid revert from zero adjustment, 2 for avoiding fee
+                output: 1, // avoid revert from zero adjustment
                 useMax: false,
                 poolId: poolId,
                 sellAsset: sellAsset
@@ -177,7 +177,7 @@ contract NormalStrategy is INormalStrategy {
             config: configs[poolId],
             order: Order({
                 input: amountIn.safeCastTo128(),
-                output: 2, // to avoid revert from zero adjustment less fee
+                output: 1, // to avoid revert from zero adjustment
                 useMax: false,
                 poolId: poolId,
                 sellAsset: sellAsset

--- a/contracts/strategies/NormalStrategy.sol
+++ b/contracts/strategies/NormalStrategy.sol
@@ -7,9 +7,6 @@ import "../libraries/PortfolioLib.sol";
 import "./INormalStrategy.sol";
 import "./NormalStrategyLib.sol";
 
-/// @dev Enforces minimum positive invariant growth for swaps in pools using this strategy.
-uint256 constant MINIMUM_INVARIANT_DELTA = 1;
-
 /// @dev Emitted when a hook is called by a non-portfolio address.
 error NormalStrategy_NotPortfolio();
 
@@ -152,7 +149,7 @@ contract NormalStrategy is INormalStrategy {
         int256 invariantAfter
     ) internal pure returns (bool) {
         int256 delta = invariantAfter - invariantBefore;
-        if (delta < int256(MINIMUM_INVARIANT_DELTA)) return false;
+        if (delta < MINIMUM_INVARIANT_DELTA) return false;
 
         return true;
     }

--- a/contracts/strategies/NormalStrategy.sol
+++ b/contracts/strategies/NormalStrategy.sol
@@ -63,6 +63,9 @@ contract NormalStrategy is INormalStrategy {
             isPerpetual: config.isPerpetual
         });
 
+        // Config storage could have been altered with `modify`.
+        config = configs[poolId];
+
         emit AfterCreate({
             portfolio: portfolio,
             poolId: poolId,

--- a/contracts/strategies/NormalStrategy.sol
+++ b/contracts/strategies/NormalStrategy.sol
@@ -227,14 +227,14 @@ contract NormalStrategy is INormalStrategy {
 
         if (sellAsset) {
             tempInput = upperX.mulWadDown(pool.liquidity) - pool.virtualX - 1;
-            tempOutput = pool.virtualY - lowerY.mulWadDown(pool.liquidity) + 1;
+            tempOutput = pool.virtualY - lowerY.mulWadDown(pool.liquidity) - 1;
             order.input =
                 tempInput.scaleFromWadDown(pair.decimalsAsset).safeCastTo128();
             order.output =
                 tempOutput.scaleFromWadDown(pair.decimalsQuote).safeCastTo128();
         } else {
             tempInput = upperY.mulWadDown(pool.liquidity) - pool.virtualY - 1;
-            tempOutput = pool.virtualX - lowerX.mulWadDown(pool.liquidity) + 1;
+            tempOutput = pool.virtualX - lowerX.mulWadDown(pool.liquidity) - 1;
 
             order.input =
                 tempInput.scaleFromWadDown(pair.decimalsQuote).safeCastTo128();

--- a/contracts/strategies/NormalStrategyLib.sol
+++ b/contracts/strategies/NormalStrategyLib.sol
@@ -245,10 +245,10 @@ function tradingFunction(NormalCurve memory self)
     // Overwrite the reserves to be as close to its bounds as possible, to avoid reverting.
     uint256 invariantTermXInput; // x - 1
     if (self.reserveXPerWad >= upperBoundX) {
-        // As x -> 1E18, 1E18 - x -> 0, Φ⁻¹(0) = -∞, therefore bound invariantTermX to 1E18 - 1E18 + 1.
+        // As x -> 1E18, 1E18 - x -> 0, Φ⁻¹(0) = -∞, therefore bound invariantTermXInput to 1E18 - 1E18 + 1.
         invariantTermXInput = 1;
     } else if (self.reserveXPerWad <= lowerBoundX) {
-        // As x -> 0, 1E18 - 0 -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound invariantTermX to 1E18 - 0 - 1.
+        // As x -> 0, 1E18 - 0 -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound invariantTermXInput to 1E18 - 0 - 1.
         invariantTermXInput = WAD - 1;
     } else {
         invariantTermXInput = WAD - self.reserveXPerWad;
@@ -257,10 +257,10 @@ function tradingFunction(NormalCurve memory self)
     uint256 invariantTermYInput =
         self.reserveYPerWad.divWadDown(self.strikePriceWad); // y/K -> [0,1]
     if (invariantTermYInput >= WAD) {
-        // As y -> K, y/K -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound y/K to 1E18 - 1.
+        // As y -> K, y/K -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound invariantTermYInput to 1E18 - 1.
         invariantTermYInput = WAD - 1;
     } else if (invariantTermYInput <= 0) {
-        // As y -> 0, y/K -> 0, Φ⁻¹(0) = -∞, therefore bound y/K to 0 + 1.
+        // As y -> 0, y/K -> 0, Φ⁻¹(0) = -∞, therefore bound invariantTermYInput to 0 + 1.
         invariantTermYInput = 1;
     }
 

--- a/contracts/strategies/NormalStrategyLib.sol
+++ b/contracts/strategies/NormalStrategyLib.sol
@@ -57,8 +57,6 @@ uint256 constant BISECTION_EPSILON = 1;
 uint256 constant BISECTION_MAX_ITER = 256;
 
 error NormalStrategyLib_ConfigExists();
-error NormalStrategyLib_UpperPriceLimitReached();
-error NormalStrategyLib_LowerPriceLimitReached();
 error NormalStrategyLib_NonExpiringPool();
 error NormalStrategyLib_InvalidDuration();
 error NormalStrategyLib_InvalidStrategyArgs();

--- a/contracts/strategies/NormalStrategyLib.sol
+++ b/contracts/strategies/NormalStrategyLib.sol
@@ -43,6 +43,8 @@ using {
 } for PortfolioConfig global;
 
 /// @dev Enforces minimum positive invariant growth for swaps in pools using this strategy.
+int256 constant INFINITY = type(int256).max;
+int256 constant NEGATIVE_INFINITY = type(int256).min;
 int256 constant MINIMUM_INVARIANT_DELTA = 1;
 uint256 constant MIN_STRIKE_PRICE = 1; // 1 wei
 uint256 constant MAX_STRIKE_PRICE = type(uint128).max;
@@ -51,6 +53,8 @@ uint256 constant MAX_VOLATILITY = 25_000; // 250%
 uint256 constant MIN_DURATION = SECONDS_PER_DAY; // Miniumum duration is one day.
 uint256 constant MAX_DURATION = SECONDS_PER_YEAR * 3; // Maximum duration is three years.
 uint256 constant STRATEGY_ARGS_LENGTH = 32 * 5; // Not packed, 5 words total = 32 * 5 = 160 bytes.
+uint256 constant BISECTION_EPSILON = 1;
+uint256 constant BISECTION_MAX_ITER = 256;
 
 error NormalStrategyLib_ConfigExists();
 error NormalStrategyLib_UpperPriceLimitReached();
@@ -112,7 +116,7 @@ function computeStdDevSqrtTau(NormalCurve memory self) pure returns (uint256) {
  * @notice
  * Computes the invariant of the RMM-01 trading function.
  *
- * @dev
+ * @dev For developers:
  * Re-arranges the trading function to remove the use of Φ (cdf).
  * By removing Φ and only using Φ⁻¹ (inverse cdf), the invariant is at least monotonic but non-strict.
  * While the Φ and Φ⁻¹ are theoretical inverses with strict monotonicity,
@@ -121,6 +125,15 @@ function computeStdDevSqrtTau(NormalCurve memory self) pure returns (uint256) {
  *
  * @custom:math
  * ```
+ * Where,
+ *        Φ   = Gaussian.cdf
+ *        Φ⁻¹ = Gaussian.ppf
+ *        K   = strikePriceWad
+ *        σ   = standardDeviationWad
+ *        τ   = timeRemainingSeconds
+ *        x   = reserveXPerWad
+ *        y   = reserveYPerWad
+ *
  * Original trading function
  * { 0    KΦ(Φ⁻¹(1-x) - σ√τ) >= y
  * { -∞   otherwise
@@ -140,10 +153,84 @@ function computeStdDevSqrtTau(NormalCurve memory self) pure returns (uint256) {
  *  -> Φ⁻¹(1-x) = Φ⁻¹(y/K) + σ√τ - k
  *      -> 1-x = Φ(Φ⁻¹(y/K) + σ√τ - k)
  *          -> x = 1 - Φ(Φ⁻¹(y/K) + σ√τ - k)
- *
  * ```
- * note
- * Slightly different from original trading function because invariant is different.
+ *
+ * # Special Boundary Properties
+ *
+ * The Φ⁻¹(y/K) term is denoted as `invariantTermY`
+ * The Φ⁻¹(1-x) term is denoted as `invariantTermX`.
+ *
+ * As y approaches its upper bound of K, Φ⁻¹(y/K) approaches +∞.
+ * As y approaches its lower bound of 0, Φ⁻¹(y/K) approaches -∞.
+ * As x approaches its upper bound of 1, Φ⁻¹(1-x) approaches -∞.
+ * As x approaches its lower bound of 0, Φ⁻¹(1-x) approaches +∞.
+ *
+ * Theoretically, if both x and y are at opposite bounds, they cancel eachother out.
+ * Pragmatically, it's a lot messier because infinity does not exist.
+ *
+ * To handle this special property, the x and y reserves are checked for exceeding their bounds.
+ * If they do exceed a bound, they are overwritten to be at the bound minus 1.
+ * This prevents reverts that would happen if inputting values outside the theoretically and
+ * practial domain of the `Gaussian.ppf` function, i.e. inputs of 0 or 1.
+ *
+ * By setting either or both the x and y to their bounds minus 1, each term will
+ * return the `ppf`'s effective minimum and maximum output.
+ *
+ * The maximum output of Φ⁻¹(1E18 - 1) = 8710427241990476442 [~8.71e18]. In wad units.
+ * The minimum output of Φ⁻¹(0 + 1)   = -8710427241990476442 [~-8.71e18]. In wad units.
+ *
+ * It's likely that the x and y reserves will reach opposite bounds,
+ * in which case the invariant terms completely cancel out, returning `k = σ√τ`.
+ *
+ * In the case only one bound is reached, the invariant term for the bound will
+ * be either the min or max output of the ppf. This will require the other term
+ * to be very close to the min or max output of the ppf in order to cancel out.
+ *
+ * note Assumes maximum values are from valid pools created via this strategy in Portfolio.
+ *
+ * ## Example
+ * The maximum value of σ√τ, where σ_max = 25_000 and τ_max = 94670859, is 4330127017500000000 [4.33e18].
+ * The minimum value of σ√τ is 0.
+ *
+ * If all y tokens are removed, Φ⁻¹(0/K) -> Φ⁻¹(1e-18) = `invariantTermY` = -8710427241990476442.
+ * For the swap to pass, the invariant needs to grow by at least 1.
+ * Assuming we started at k = 0, we need to find the `invariantTermX` that solves this:
+ *      -> 1 = -8710427241990476442 - invariantTermX + σ√τ.
+ * We need the σ√τ term to help us, so we can set it to its maximum value. Now we have:
+ *      -> 1 = -8710427241990476442 - invariantTermX + 4330127017500000000.
+ *      -> invariantTermX <= -8710427241990476442 + 4330127017500000000 - 1.
+ *      -> invariantTermX <= -4380300224490476443 [~-4.38e18].
+ *      -> Φ⁻¹(1-x) <= -4.380300224490476443. (not in wad anymore...)
+ *      -> 1 - x <= Φ(-4.380300224490476443).
+ *      -> x >= 1 - Φ(-4.380300224490476443).
+ *      -> x >= ~0.999999218479338350565045237958.
+ * In conclusion, to take all y reserves, the x reserves must be __very close__ to its upper bound.
+ *
+ *
+ * If all x tokens are removed, `invariantTermX` = 8710427241990476442.
+ * For the swap to pass, the invariant needs to grow by at least 1.
+ *     -> 1 = invariantTermY - 8710427241990476442 + σ√τ.
+ * We can use the σ√τ to help us, so we can set it to its maximum value. Now we have:
+ *    -> 1 = invariantTermY - 8710427241990476442 + 4330127017500000000.
+ *    -> invariantTermY >= 8710427241990476442 - 4330127017500000000 + 1.
+ *    -> invariantTermY >= 4380300224490476443 [~4.38e18].
+ *    -> Φ⁻¹(y/K) >= 4.380300224490476443. (not in wad anymore...)
+ *    -> y/K >= Φ(4.380300224490476443).
+ *    -> y >= KΦ(4.380300224490476443).
+ *    -> y >= K * ~0.999994074204725119575460221025.
+ * However, since the `invariantTermX` will be subtracted from `invariantTermY` first, it will
+ * revert the transaction with an arithemtic underflow unless the `invariantTermX` is equal
+ * to it's maximum value of 8710427241990476442, which is when the y reserves are at their
+ * upper bound of y = k.
+ * In conclusion, to take all x reserves, the y reserves __must__ be at its upper bound.
+ *
+ * This overwrite of "infinity" effectively makes the trading function return an actual value
+ * at the bounds, instead of reverting. This is important for pools which might have accrued
+ * enough fees to push one of it's reserves over the bounds. Additionally, a maximum and minimum
+ * price are effectively enforced at these boundaries.
+ *
+ *
+ * note Adjusted trading function's invariant != original trading function's invariant.
  *
  * @return invariant        k; Signed invariant of the pool.
  */
@@ -158,19 +245,33 @@ function tradingFunction(NormalCurve memory self)
     (uint256 upperBoundX, uint256 lowerBoundX) = self.getReserveXBounds();
     (uint256 upperBoundY, uint256 lowerBoundY) = self.getReserveYBounds();
 
-    // Check if the reserves are within the boundary before computing its respective invariant term.
-    // This is required because the invariant term for x approaches 0 or 1 as x approaches its bounds.
-    // Taking the percent point function of 0 or 1 will result in an error, which we purposefully avoid.
-    int256 invariantTermX; // Φ⁻¹(1-x)
-    if (self.reserveXPerWad.isBetween(lowerBoundX + 1, upperBoundX - 1)) {
-        invariantTermX = Gaussian.ppf(int256(WAD - self.reserveXPerWad));
+    // Overwrite the reserves to be as close to its bounds as possible, to avoid reverting.
+    uint256 invariantTermXInput; // x - 1
+    if (self.reserveXPerWad >= upperBoundX) {
+        // As x -> 1E18, 1E18 - x -> 0, Φ⁻¹(0) = -∞, therefore bound invariantTermX to 1E18 - 1E18 + 1.
+        invariantTermXInput = 1;
+    } else if (self.reserveXPerWad <= lowerBoundX) {
+        // As x -> 0, 1E18 - 0 -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound invariantTermX to 1E18 - 0 - 1.
+        invariantTermXInput = WAD - 1;
+    } else {
+        invariantTermXInput = WAD - self.reserveXPerWad;
     }
-    int256 invariantTermY; // Φ⁻¹(y/K)
-    if (self.reserveYPerWad.isBetween(lowerBoundY + 1, upperBoundY - 1)) {
-        invariantTermY = Gaussian.ppf(
-            int256(self.reserveYPerWad.divWadUp(self.strikePriceWad))
-        );
+
+    uint256 invariantTermYInput; // y/K
+    if (self.reserveYPerWad >= upperBoundY) {
+        // As y -> K, y/K -> 1E18, Φ⁻¹(1E18) = +∞, therefore bound y/K to 1E18 - 1.
+        invariantTermYInput = WAD - 1;
+    } else if (self.reserveYPerWad <= lowerBoundY) {
+        // As y -> 0, y/K -> 0, Φ⁻¹(0) = -∞, therefore bound y/K to 0 + 1.
+        invariantTermYInput = 1;
+    } else {
+        invariantTermYInput = self.reserveYPerWad.divWadUp(self.strikePriceWad); // forgefmt:disable-line
     }
+
+    // Φ⁻¹(1-x)
+    int256 invariantTermX = Gaussian.ppf(int256(invariantTermXInput));
+    // Φ⁻¹(y/K)
+    int256 invariantTermY = Gaussian.ppf(int256(invariantTermYInput));
 
     // k = Φ⁻¹(y/K) - Φ⁻¹(1-x) + σ√τ
     invariant = invariantTermY - invariantTermX + int256(stdDevSqrtTau);
@@ -181,7 +282,7 @@ function tradingFunction(NormalCurve memory self)
  * Computes the x reserves given y reserves.
  *
  * @dev
- * Derived from the original trading function defined in `tradingFunction`.
+ * Derived from the __adjusted__ trading function defined in `tradingFunction`.
  *
  * @custom:math
  * x = 1 - Φ(Φ⁻¹(y/K) + σ√τ - k)
@@ -214,7 +315,7 @@ function approximateXGivenY(NormalCurve memory self)
  * Computes the y reserves given x reserves.
  *
  * @dev
- * Derived from the original trading function.
+ * Derived from the __adjusted__ trading function.
  *
  * @custom:math
  * y = KΦ(Φ⁻¹(1-x) - σ√τ + k)
@@ -696,6 +797,7 @@ library NormalStrategyLib {
 
         NormalCurve memory curve = transform(config);
         curve.invariant = prevInv;
+        curve.timeRemainingSeconds = config.computeTau(timestamp);
 
         uint256 adjustedDependentReserve;
         bool sellAsset = order.sellAsset;
@@ -720,9 +822,8 @@ library NormalStrategyLib {
             return (sellAsset ? self.virtualY : self.virtualX);
         }
 
-        uint256 lower = adjustedDependentReserve.mulDivDown(98, 100);
-        uint256 upper = adjustedDependentReserve.mulDivUp(102, 100);
-
+        uint256 lower = adjustedDependentReserve.mulDivDown(50, 100);
+        uint256 upper = adjustedDependentReserve.mulDivUp(150, 100);
         // Output reserve is approximated with the derived math functions,
         // but to get it precise it needs a root finding algorithm.
         // Approximates the dependent reserve per liquidity by finding the root of the trading function.
@@ -730,8 +831,8 @@ library NormalStrategyLib {
             abi.encode(curve),
             lower,
             upper,
-            0, // Set to 0 to find the exact dependent reserve which sets the invariant to 0.
-            256, // Maximum amount of loops to run in bisection.
+            BISECTION_EPSILON, // Set to 1 to find the exact dependent reserve which increases invariant by 1.
+            BISECTION_MAX_ITER, // Maximum amount of loops to run in bisection.
             sellAsset ? findRootForSwappingInX : findRootForSwappingInY
         );
 

--- a/contracts/strategies/NormalStrategyLib.sol
+++ b/contracts/strategies/NormalStrategyLib.sol
@@ -305,7 +305,6 @@ function approximatePriceGivenX(
     uint256 reserveXPerWad
 ) pure returns (uint256 priceWad) {
     (uint256 upperBoundX, uint256 lowerBoundX) = self.getReserveXBounds();
-    (uint256 upperBoundY, uint256 lowerBoundY) = self.getReserveYBounds();
 
     if (reserveXPerWad >= upperBoundX) return self.strikePriceWad; // Terminal price limit.
     if (reserveXPerWad <= lowerBoundX) return type(uint128).max; // Upper price limit.

--- a/contracts/strategies/NormalStrategyLib.sol
+++ b/contracts/strategies/NormalStrategyLib.sol
@@ -36,6 +36,8 @@ using {
 
 using { encode, modify, transform } for PortfolioConfig global;
 
+/// @dev Enforces minimum positive invariant growth for swaps in pools using this strategy.
+int256 constant MINIMUM_INVARIANT_DELTA = 1;
 uint256 constant MIN_STRIKE_PRICE = 1; // 1 wei
 uint256 constant MAX_STRIKE_PRICE = type(uint128).max;
 uint256 constant MIN_VOLATILITY = 1; // 0.01%
@@ -647,10 +649,11 @@ library NormalStrategyLib {
         uint256 value
     ) internal pure returns (int256) {
         // Optimize the trading function such that it is strictly monotonically increasing.
-        // Find the root: f(x) - invariant + 2 = 0
+        // Find the root: f(x) - (invariant + min invariant delta) = 0
         NormalCurve memory curve = abi.decode(args, (NormalCurve));
         curve.reserveYPerWad = value;
-        return tradingFunction(curve) - (curve.invariant + 1);
+        return
+            tradingFunction(curve) - (curve.invariant + MINIMUM_INVARIANT_DELTA);
     }
 
     function findRootForSwappingInY(
@@ -658,10 +661,11 @@ library NormalStrategyLib {
         uint256 value
     ) internal pure returns (int256) {
         // Optimize the trading function such that it is strictly monotonically increasing.
-        // Find the root: f(x) - invariant + 2 = 0
+        // Find the root: f(x) - (invariant + min invariant delta) = 0
         NormalCurve memory curve = abi.decode(args, (NormalCurve));
         curve.reserveXPerWad = value;
-        return tradingFunction(curve) - (curve.invariant + 1);
+        return
+            tradingFunction(curve) - (curve.invariant + MINIMUM_INVARIANT_DELTA);
     }
 
     // ----------------- //

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -133,9 +133,9 @@ contract Setup is ISetup, Test, ERC1155TokenReceiver {
 
     /// @dev Uses the global test Configuration type to create a pool and set the ghost state.
     function activateConfig(Configuration memory config) internal {
-        if (config.asset == address(0) && config.quote == address(0)) {
-            (config.asset, config.quote) = deployDefaultTokenPair();
-        }
+        (address asset, address quote) = deployDefaultTokenPair();
+        if (config.asset == address(0)) config.asset = asset;
+        if (config.quote == address(0)) config.quote = quote;
 
         // Makes it accessible for debugging via `Setup.global_config()`.
         _global_config = config;
@@ -366,6 +366,15 @@ contract Setup is ISetup, Test, ERC1155TokenReceiver {
         Coin quote = deployCoin("token", abi.encode("quote", "QUOTE", 18));
         Configuration memory config = configureNormalStrategy();
         (config.asset, config.quote) = (weth(), quote.to_addr());
+
+        activateConfig(config);
+        _;
+    }
+
+    modifier customTokenConfig(bool isAsset, address token) {
+        Configuration memory config = configureNormalStrategy();
+        if (isAsset) config.asset = token;
+        else config.quote = token;
 
         activateConfig(config);
         _;

--- a/test/TestAssemblyLib.t.sol
+++ b/test/TestAssemblyLib.t.sol
@@ -46,4 +46,19 @@ contract TestAssemblyLib is Test {
             output, delta < 0 ? input - uint128(-delta) : input + uint128(delta)
         );
     }
+
+    function test_pack() public {
+        bytes1 to_pack = 0x01;
+        bytes1 packed = AssemblyLib.pack(to_pack, 0x0);
+        assertEq(uint8(packed), uint8(0x10), "upper packed");
+        assertEq(uint8(packed & 0x0f), 0x00, "lower packed");
+    }
+
+    function test_separate() public {
+        bytes1 to_pack = 0x01;
+        bytes1 packed = AssemblyLib.pack(to_pack, 0x0);
+        (bytes1 unpacked, bytes1 unpacked_zero) = AssemblyLib.separate(packed);
+        assertEq(uint8(unpacked), uint8(to_pack), "unpacked");
+        assertEq(uint8(unpacked_zero), 0x00, "unpacked_zero");
+    }
 }

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -160,7 +160,7 @@ contract TestGas is Setup {
         for (uint256 i; i != 2; ++i) {
             uint64 poolId;
             if (i == 0) poolId = ghost().poolId;
-            else poolId = AssemblyLib.encodePoolId(uint24(2), false, uint32(1));
+            else poolId = PoolIdLib.encode(false, false, uint24(2), uint32(1));
 
             instructions[i] = abi.encodeCall(
                 IPortfolioActions.allocate,
@@ -271,7 +271,7 @@ contract TestGas is Setup {
                 hundred, // fee
                 0, // prior fee
                 address(0), // controller
-                subject().DEFAULT_STRATEGY(),
+                address(0), // default strategy
                 testConfig.strategyArgs
             )
         );
@@ -283,7 +283,7 @@ contract TestGas is Setup {
         for (uint256 i; i != 2; ++i) {
             uint64 poolId;
             if (i == 0) poolId = ghost().poolId;
-            else poolId = AssemblyLib.encodePoolId(uint24(2), false, uint32(1));
+            else poolId = PoolIdLib.encode(false, false, uint24(2), uint32(1));
 
             bytes[] memory go = new bytes[](1);
             go[0] = abi.encodeCall(
@@ -567,8 +567,9 @@ contract TestGas is Setup {
         }
 
         // Super important
-        uint64 poolId = AssemblyLib.encodePoolId(
-            uint24(1), controller != address(0), uint32(1)
+        bool altered = false;
+        uint64 poolId = PoolIdLib.encode(
+            altered, controller != address(0), uint24(1), uint32(1)
         );
         // By setting this poolId all the modifiers that rely on the tokens asset and quote
         // can use this set poolId's pair. Since we created all the pools with the same pair,
@@ -769,8 +770,8 @@ contract TestGas is Setup {
         }
 
         uint24 pairId = 1;
-        uint64 poolId = AssemblyLib.encodePoolId(
-            pairId, false, subject().getPoolNonce(pairId) + 1
+        uint64 poolId = PoolIdLib.encode(
+            false, false, pairId, subject().getPoolNonce(pairId) + 1
         );
 
         bytes[] memory instructions = new bytes[](2);
@@ -901,8 +902,8 @@ contract TestGas is Setup {
         }
 
         uint24 pairId = 1;
-        uint64 poolId = AssemblyLib.encodePoolId(
-            pairId, false, subject().getPoolNonce(pairId) + 1
+        uint64 poolId = PoolIdLib.encode(
+            false, false, pairId, subject().getPoolNonce(pairId) + 1
         );
 
         bytes[] memory instructions = new bytes[](2);

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -722,7 +722,9 @@ contract TestGas is Setup {
         bool direction,
         uint64 poolId
     ) internal view returns (bytes memory) {
-        uint128 amountIn = uint128(0.05 ether);
+        Order memory maxOrder =
+            subject().getMaxOrder(poolId, direction, actor());
+        uint128 amountIn = maxOrder.input / 2;
         uint128 amountOut = subject().getAmountOut(
             poolId, direction, amountIn, actor()
         ).safeCastTo128();

--- a/test/TestPortfolio.t.sol
+++ b/test/TestPortfolio.t.sol
@@ -21,7 +21,7 @@ contract TestPortfolio is Setup {
         uint32 poolNonce = 1;
 
         uint64 encoded =
-            PoolIdLib.encode(controlled, altered, pairId, poolNonce);
+            PoolIdLib.encode(altered, controlled, pairId, poolNonce);
 
         uint64 poolId_ = uint64(bytes8(hex"1100000200000001"));
         assertEq(encoded, poolId_, "pool id");
@@ -33,6 +33,50 @@ contract TestPortfolio is Setup {
         assertEq(uint32(encoded), poolNonce, "pool nonce");
         assertEq(uint24(encoded >> 32), pairId, "pair id");
         assertEq(uint8(encoded >> 56), 0x11, "controlled and altered");
+        assertEq(
+            uint8(bytes1(bytes1(uint8(encoded >> 56)) & 0x0f)),
+            controlled ? 1 : 0,
+            "controlled"
+        );
+        assertEq(uint8(encoded >> 60), altered ? 1 : 0, "altered");
+    }
+
+    function test_encode_pool_id_altered_not_controlled() public {
+        bool altered = true;
+        bool controlled = false;
+        uint24 pairId = 2;
+        uint32 poolNonce = 1;
+
+        uint64 encoded =
+            PoolIdLib.encode(altered, controlled, pairId, poolNonce);
+
+        assertEq(PoolId.wrap(encoded).altered(), altered, "altered-method");
+        assertEq(
+            PoolId.wrap(encoded).controlled(), controlled, "controlled-method"
+        );
+        assertEq(uint8(encoded >> 56), 0x10, "first byte");
+        assertEq(
+            uint8(bytes1(bytes1(uint8(encoded >> 56)) & 0x0f)),
+            controlled ? 1 : 0,
+            "controlled"
+        );
+        assertEq(uint8(encoded >> 60), altered ? 1 : 0, "altered");
+    }
+
+    function test_encode_pool_id_not_altered_controlled() public {
+        bool altered = false;
+        bool controlled = true;
+        uint24 pairId = 2;
+        uint32 poolNonce = 1;
+
+        uint64 encoded =
+            PoolIdLib.encode(altered, controlled, pairId, poolNonce);
+
+        assertEq(PoolId.wrap(encoded).altered(), altered, "altered-method");
+        assertEq(
+            PoolId.wrap(encoded).controlled(), controlled, "controlled-method"
+        );
+        assertEq(uint8(encoded >> 56), 0x01, "first byte");
         assertEq(
             uint8(bytes1(bytes1(uint8(encoded >> 56)) & 0x0f)),
             controlled ? 1 : 0,

--- a/test/TestPortfolio.t.sol
+++ b/test/TestPortfolio.t.sol
@@ -12,4 +12,46 @@ contract TestPortfolio is Setup {
         vm.expectRevert(Portfolio_InvalidReentrancy.selector);
         subject().allocate(false, address(this), ghost().poolId, 1 ether, 0, 0);
     }
+
+    function test_encode_pool_id() public {
+        bool controlled = true;
+        bool altered = true;
+        uint24 pairId = 2;
+        uint32 poolNonce = 1;
+
+        uint64 encoded =
+            PoolIdLib.encode(controlled, altered, pairId, poolNonce);
+
+        uint64 poolId_ = uint64(bytes8(hex"1100000200000001"));
+        assertEq(encoded, poolId_, "pool id");
+        assertEq(PoolId.wrap(poolId_).altered(), altered, "altered-method");
+        assertEq(
+            PoolId.wrap(poolId_).controlled(), controlled, "controlled-method"
+        );
+        assertEq(PoolId.wrap(poolId_).nonce(), uint32(encoded), "pool-nonce");
+        assertEq(uint32(encoded), poolNonce, "pool nonce");
+        assertEq(uint24(encoded >> 32), pairId, "pair id");
+        assertEq(uint8(encoded >> 56), 0x11, "controlled and altered");
+        assertEq(
+            uint8(bytes1(bytes1(uint8(encoded >> 56)) & 0x0f)),
+            controlled ? 1 : 0,
+            "controlled"
+        );
+        assertEq(uint8(encoded >> 60), altered ? 1 : 0, "altered");
+    }
+
+    function test_pair_id_encode() public {
+        bool controlled = true;
+        bool altered = true;
+        uint24 pairId = 2;
+        uint32 poolNonce = 1;
+
+        uint64 encoded =
+            PoolIdLib.encode(controlled, altered, pairId, poolNonce);
+
+        assertEq(uint24(encoded >> 32), pairId, "pair id");
+
+        uint24 expected = PoolId.wrap(encoded).pairId();
+        assertEq(expected, uint24(encoded >> 32), "pair id method");
+    }
 }

--- a/test/TestPortfolio.t.sol
+++ b/test/TestPortfolio.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import "./Setup.sol";
+import "../contracts/libraries/SafeTransferLib.sol" as TransferLib;
 
 contract TestPortfolio is Setup {
     uint256 constant LOCKED_SLOT = 12; // `$ forge inspect Portfolio storageLayout`
@@ -53,5 +54,106 @@ contract TestPortfolio is Setup {
 
         uint24 expected = PoolId.wrap(encoded).pairId();
         assertEq(expected, uint24(encoded >> 32), "pair id method");
+    }
+
+    address internal _malicious;
+
+    modifier makeMaliciousToken() {
+        _malicious = address(new MaliciousReentrancyToken());
+        _;
+    }
+
+    /// @dev To set this test up, we need to inject a single-call re-entrancy
+    /// using the `transferFrom` function on a malicious token.
+    /// This will get triggered during settlement.
+    /// multicall
+    ///     preLock()
+    ///         allocate()
+    ///     postLock()
+    ///     settlement()
+    ///        transferFrom()
+    ///            multicall()
+    ///                preLock()
+    /// ...             should revert here.
+    function test_reentrancy_duing_multicall_settlement()
+        public
+        makeMaliciousToken
+        customTokenConfig(true, _malicious)
+        useActor
+        usePairTokens(100 ether)
+    {
+        bytes[] memory instructions = new bytes[](1);
+        instructions[0] = abi.encodeCall(
+            IPortfolioActions.allocate,
+            (
+                false,
+                address(this),
+                ghost().poolId,
+                1 ether, // make sure we can provide enough liquidity...
+                type(uint128).max,
+                type(uint128).max
+            )
+        );
+
+        // Send some tokens to the malicious token contract so it can allocate...
+        ghost().asset().to_token().transfer(_malicious, 25 ether);
+        ghost().quote().to_token().transfer(_malicious, 25 ether);
+
+        IPortfolio subject_ = subject();
+
+        // The call originally reverts with `Portfolio_InvalidInvariant`, however...
+        // because the external call was `safeTransferFrom`, the revert is caught
+        // and the `TokenTransferFrom` error is thrown instead.
+        // Pass the -vvv flag to the test command to see the revert message.
+        // forge test -vvv --match-test test_reentrancy_duing_multicall_settlement
+        vm.expectRevert(TransferLib.TokenTransferFrom.selector);
+        subject_.multicall(instructions);
+    }
+}
+
+contract MaliciousReentrancyToken is ERC20, ERC1155TokenReceiver {
+    constructor() ERC20("MaliciousReentrancy", "MUTEX", 18) {
+        if (block.chainid == 1) revert("bad");
+    }
+
+    uint64 internal _poolId;
+
+    function set(uint64 poolId) external {
+        _poolId = poolId;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @dev Malicious re-entrancy in untrusted & dangerous `transferFrom` call in settlement.
+    /// Portfolio.settlement
+    ///    this.transferFrom()
+    ///        msg.sender.multicall()
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public override returns (bool) {
+        // Re-enter here.
+        bytes[] memory instructions = new bytes[](1);
+        instructions[0] = abi.encodeCall(
+            IPortfolioActions.allocate,
+            (
+                false,
+                address(this),
+                _poolId,
+                1 ether, // make sure we can provide enough liquidity...
+                type(uint128).max,
+                type(uint128).max
+            )
+        );
+
+        // Re-enter with multicall!
+        IPortfolio(msg.sender).multicall(instructions);
+
+        // Call the regular logic..
+        super.transferFrom(from, to, amount);
+        return true;
     }
 }

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -42,7 +42,8 @@ contract TestPortfolioAllocate is Setup {
             )
         );
 
-        uint64 poolId = AssemblyLib.encodePoolId(1, false, 1);
+        // uses non-controlled pool and default strategy, leading byte 0x00 poolId
+        uint64 poolId = PoolIdLib.encode(false, false, 1, 1);
 
         data[2] = abi.encodeCall(
             IPortfolioActions.allocate,

--- a/test/TestPortfolioCreatePool.t.sol
+++ b/test/TestPortfolioCreatePool.t.sol
@@ -207,7 +207,7 @@ contract TestPortfolioCreatePool is Setup {
             "duration != SECONDS_PER_YEAR"
         );
         assertEq(
-            ghost().poolOf(poolId).computeTau(ghost().configOf(poolId), 0),
+            ghost().configOf(poolId).computeTau(0),
             SECONDS_PER_YEAR,
             "tau != year"
         );

--- a/test/TestPortfolioCreatePool.t.sol
+++ b/test/TestPortfolioCreatePool.t.sol
@@ -198,8 +198,8 @@ contract TestPortfolioCreatePool is Setup {
         );
 
         subject().multicall(data);
-        uint64 poolId = AssemblyLib.encodePoolId(
-            pairNonce, false, uint32(subject().getPoolNonce(pairNonce))
+        uint64 poolId = PoolIdLib.encode(
+            false, false, pairNonce, uint32(subject().getPoolNonce(pairNonce))
         );
         assertEq(
             ghost().configOf(poolId).durationSeconds,


### PR DESCRIPTION
I did make a major change to the poolId encoding - it now includes a leading 0x1 flag if the strategy is not default. It also brings the 0x01 controller flag to the front, so the first byte of the poolId leads with these flags packed into the single byte. This makes it easier to discern if a pool has a non-default strategy.

I also changed getInvariant -> getInvariantDown and added getInvariantUp for functions with respective rounding directions to make it more clear whats being used and where