### PR TITLE
fix(afterCreate): adds return true to afterCreate hook

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -754,7 +754,9 @@ contract Portfolio is ERC1155, IPortfolio {
         _getLastPoolId = poolId;
 
         // This call also prevents accidently creating a pool with an invalid strategy target address.
-        IStrategy(getStrategy(poolId)).afterCreate(poolId, strategyArgs);
+        bool success =
+            IStrategy(getStrategy(poolId)).afterCreate(poolId, strategyArgs);
+        if (!success) revert Portfolio_AfterCreateFail();
 
         emit CreatePool(
             poolId,

--- a/contracts/libraries/PortfolioLib.sol
+++ b/contracts/libraries/PortfolioLib.sol
@@ -9,6 +9,7 @@ import "./ConstantsLib.sol" as ConstantsLib;
 import "./PoolLib.sol";
 import "./SwapLib.sol";
 
+error Portfolio_AfterCreateFail();
 error Portfolio_BeforeSwapFail();
 error Portfolio_DuplicateToken();
 error Portfolio_Insolvent(address token, int256 net);

--- a/contracts/strategies/NormalStrategy.sol
+++ b/contracts/strategies/NormalStrategy.sol
@@ -74,6 +74,8 @@ contract NormalStrategy is INormalStrategy {
             durationSeconds: config.durationSeconds,
             isPerpetual: config.isPerpetual
         });
+
+        return true;
     }
 
     /// @inheritdoc IStrategy


### PR DESCRIPTION
In NormalStrategy.sol the `afterCreate` hook should return a bool to signal success or failure, however there is no return statement and the `success` variable is never set to true, so the function always returns false.