### PR TITLE
fix(#439): updates trading function bound case

### DIFF
--- a/test/TestPortfolioSwap.t.sol
+++ b/test/TestPortfolioSwap.t.sol
@@ -555,19 +555,10 @@ contract TestPortfolioSwap is Setup {
         // This swap takes all of the quote token "y" out of the pool.
         // Therefore, we will hit the "lower bound" case for the "y" reserves.
         // This will make the invariant y term `Gaussian.ppf(1)`, which is -8710427241990476442.
-        // Then it will subtract the invariantTermX and add the stdDevSqrtTau term.
-        // The minimum value for the invariantTermX is the same, `Gaussian.ppf(1)`, which is -8710427241990476442.
-        // Therefore, the x reserve needs to be close to its upper bound, since the input to the ppf is 1 - x.
-        // If it is close or at the boundary, it will cancel out the invariant y term.
-        // If its not close, the stdDevSqrtTau term will need to be large enough to close the difference,
-        // which might be too large than that term could be.
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Portfolio_InvalidInvariant.selector,
-                int256(938),
-                int256(-8707810991428151127)
-            )
-        );
+        // This requires the asset token "x" reserves to be at the upper bound of 1 WAD.
+        // If both reserves are not at opposite bounds, it will revert.
+        // In this case, it will revert with the `NormalStrategyLib_UpperReserveXBoundNotReached` error.
+        vm.expectRevert(NormalStrategyLib_UpperReserveXBoundNotReached.selector);
         subject_.swap(order);
     }
 


### PR DESCRIPTION
# Changes

Updates the NormalStrategyLib.tradingFunction to explicitly handle the boundary case.
- Adds four new custom errors that are used when one reserve is at the bound but the other reserve is not at the opposite bound.
- Adds two branches of code in trading function:
  - 1. If x >= WAD || y <= 0, then checks if the other reserve is at the opposite bound, if not it reverts, else it returns σ√τ
  - 2. If x <= 0 || y >= WAD, then checks if other reserve is at the opposite bound, if not it reverts, else it returns σ√τ
  - 3. Else, computes the trading function regularly

There needs to be some updates to the test suite to test these boundary cases better. Right now, there are fuzz tests that fuzz a broad space of parameters and reserves, but these should be more concentrated on fuzzing the reserve changes against a few specific parameter profiles.