### PR TITLE
feat(no-default): removes default normal strategy

### DIFF
--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -7,7 +7,6 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IPortfolio.sol";
 import "./interfaces/IPortfolioRegistry.sol";
 import "./interfaces/IStrategy.sol";
-import "./strategies/NormalStrategy.sol";
 import "./PositionRenderer.sol";
 
 /**
@@ -55,9 +54,6 @@ contract Portfolio is ERC1155, IPortfolio {
 
     /// @inheritdoc IPortfolioState
     address public immutable REGISTRY;
-
-    /// @inheritdoc IPortfolioState
-    address public immutable DEFAULT_STRATEGY;
 
     /// @inheritdoc IPortfolioState
     address public immutable POSITION_RENDERER;
@@ -206,7 +202,6 @@ contract Portfolio is ERC1155, IPortfolio {
     ) ERC1155() {
         WETH = weth;
         REGISTRY = registry;
-        DEFAULT_STRATEGY = address(new NormalStrategy(address(this)));
         POSITION_RENDERER = positionRenderer;
         __account__.settled = true;
     }
@@ -729,12 +724,9 @@ contract Portfolio is ERC1155, IPortfolio {
         // Increment the pool nonce.
         uint32 poolNonce = ++getPoolNonce[pairNonce];
 
-        // Zero address strtaegy is a magic value to use the default strategy.
-        strategy = strategy == address(0) ? DEFAULT_STRATEGY : strategy;
-
         // Compute the poolId, which is a packed 64-bit integer.
         poolId = PoolIdLib.encode(
-            strategy != DEFAULT_STRATEGY, // Flips the "altered" flag in the upper 4 bits: "0x10..."
+            true, // Flips the "altered" flag in the upper 4 bits: "0x10..."
             controller != address(0), // Flips the "controlled" flag in the lower 4 bits:  "0x01..."
             pairNonce,
             poolNonce

--- a/contracts/Portfolio.sol
+++ b/contracts/Portfolio.sol
@@ -726,7 +726,7 @@ contract Portfolio is ERC1155, IPortfolio {
 
         // Compute the poolId, which is a packed 64-bit integer.
         poolId = PoolIdLib.encode(
-            true, // Flips the "altered" flag in the upper 4 bits: "0x10..."
+            false, // Flips the "altered" flag in the upper 4 bits: "0x10..."
             controller != address(0), // Flips the "controlled" flag in the lower 4 bits:  "0x01..."
             pairNonce,
             poolNonce

--- a/contracts/PositionRenderer.sol
+++ b/contracts/PositionRenderer.sol
@@ -45,7 +45,6 @@ contract PositionRenderer {
         address controller;
         address strategy;
         uint256 spotPriceWad;
-        bool hasDefaultStrategy;
     }
 
     struct Config {
@@ -157,9 +156,7 @@ contract PositionRenderer {
             priorityFeeBasisPoints: priorityFeeBasisPoints,
             controller: controller,
             strategy: strategy,
-            spotPriceWad: spotPriceWad,
-            hasDefaultStrategy: strategy
-                == IPortfolio(msg.sender).DEFAULT_STRATEGY()
+            spotPriceWad: spotPriceWad
         });
     }
 
@@ -598,9 +595,7 @@ contract PositionRenderer {
                 '<div class="f"><p>',
                 controlledLabel,
                 " and uses ",
-                properties.pool.hasDefaultStrategy
-                    ? "the default strategy."
-                    : "a custom strategy.",
+                "a custom strategy.",
                 "</p></div>"
             )
         );

--- a/contracts/interfaces/IPortfolio.sol
+++ b/contracts/interfaces/IPortfolio.sol
@@ -216,9 +216,6 @@ interface IPortfolioState {
     /// @notice Contract for rendering position tokens.
     function POSITION_RENDERER() external view returns (address);
 
-    /// @notice Default strategy contract used in pool creation.
-    function DEFAULT_STRATEGY() external view returns (address);
-
     /// @notice Proportion of swap fee allocated to the Registry controller.
     function protocolFee() external view returns (uint256);
 

--- a/test/ETHSP.t.sol
+++ b/test/ETHSP.t.sol
@@ -235,10 +235,12 @@ contract ETHSP is Setup {
         Configuration memory TRANCHE_A_CONFIG = CONFIG.edit(
             "asset", abi.encode(TOKEN_0)
         ).edit("quote", abi.encode(TOKEN_1));
+        TRANCHE_A_CONFIG.strategy = normalStrategy();
 
         Configuration memory TRANCHE_B_CONFIG = CONFIG.edit(
             "asset", abi.encode(TOKEN_2)
         ).edit("quote", abi.encode(TOKEN_3));
+        TRANCHE_B_CONFIG.strategy = normalStrategy();
         // Creates the pools with the configs.
         TRANCHE_A_POOL = TRANCHE_A_CONFIG.activate(
             address(subject()), NormalConfiguration.validateNormalStrategy

--- a/test/Setup.sol
+++ b/test/Setup.sol
@@ -34,6 +34,7 @@ struct SubjectsType {
     address weth;
     address portfolio;
     address positionRenderer;
+    address normalStrategy;
 }
 
 // Interfaces
@@ -70,6 +71,9 @@ interface ISetup {
 
     /// @dev Returns the position renderer contract used in the subject.
     function positionRenderer() external view returns (address);
+
+    /// @dev Returns the normal strategy address.
+    function normalStrategy() external view returns (address);
 }
 
 contract Setup is ISetup, Test, ERC1155TokenReceiver {
@@ -115,6 +119,10 @@ contract Setup is ISetup, Test, ERC1155TokenReceiver {
         );
         vm.label(_subjects.portfolio, "portfolio");
 
+        _subjects.normalStrategy =
+            address(new NormalStrategy(_subjects.portfolio));
+        vm.label(_subjects.normalStrategy, "normal-strategy");
+
         _ghost_state = GhostType({
             actor: address(this),
             subject: _subjects.portfolio,
@@ -136,6 +144,7 @@ contract Setup is ISetup, Test, ERC1155TokenReceiver {
         (address asset, address quote) = deployDefaultTokenPair();
         if (config.asset == address(0)) config.asset = asset;
         if (config.quote == address(0)) config.quote = quote;
+        config.strategy = normalStrategy();
 
         // Makes it accessible for debugging via `Setup.global_config()`.
         _global_config = config;
@@ -499,6 +508,11 @@ contract Setup is ISetup, Test, ERC1155TokenReceiver {
     /// @inheritdoc ISetup
     function positionRenderer() public view override returns (address) {
         return _subjects.positionRenderer;
+    }
+
+    /// @inheritdoc ISetup
+    function normalStrategy() public view override returns (address) {
+        return _subjects.normalStrategy;
     }
 
     receive() external payable { }

--- a/test/TestGas.t.sol
+++ b/test/TestGas.t.sol
@@ -148,7 +148,7 @@ contract TestGas is Setup {
                 hundred, // fee
                 0, // prior fee
                 address(0), // controller
-                subject().DEFAULT_STRATEGY(),
+                normalStrategy(),
                 testConfig.strategyArgs
             )
         );
@@ -271,7 +271,7 @@ contract TestGas is Setup {
                 hundred, // fee
                 0, // prior fee
                 address(0), // controller
-                address(0), // default strategy
+                normalStrategy(),
                 testConfig.strategyArgs
             )
         );
@@ -559,7 +559,7 @@ contract TestGas is Setup {
                         uint16(100 + 100 / i), // fee
                         0, // prior fee
                         controller,
-                        subject().DEFAULT_STRATEGY(),
+                        normalStrategy(),
                         testConfig.strategyArgs
                     )
                 );
@@ -692,7 +692,7 @@ contract TestGas is Setup {
                 uint16(100), // fee
                 uint16(10), // prior fee
                 address(0), // controller
-                subject().DEFAULT_STRATEGY(),
+                normalStrategy(),
                 testConfig.strategyArgs
             )
         );

--- a/test/TestPortfolioAllocate.t.sol
+++ b/test/TestPortfolioAllocate.t.sol
@@ -37,7 +37,7 @@ contract TestPortfolioAllocate is Setup {
                 100, // fee
                 0, // prior fee
                 address(0), // controller
-                subject().DEFAULT_STRATEGY(),
+                normalStrategy(),
                 testConfig.strategyArgs
             )
         );
@@ -610,7 +610,7 @@ contract TestPortfolioAllocate is Setup {
             30, // fee
             0, // priority fee
             address(0),
-            subject().DEFAULT_STRATEGY(),
+            normalStrategy(),
             testConfig.strategyArgs
         );
 

--- a/test/TestPortfolioCreatePool.t.sol
+++ b/test/TestPortfolioCreatePool.t.sol
@@ -61,27 +61,6 @@ contract TestPortfolioCreatePool is Setup {
         );
     }
 
-    function test_createPool_no_strategy_defaults() public defaultConfig {
-        Configuration memory testConfig = configureNormalStrategy();
-
-        testConfig.reserveXPerWad++; // Avoid the reserve error
-        testConfig.reserveYPerWad++; // Avoid the reserve error
-
-        uint64 poolId = subject().createPool(
-            0,
-            testConfig.reserveXPerWad,
-            testConfig.reserveYPerWad,
-            100, // fee
-            0, // prior fee
-            address(0), // controller
-            address(0), // strategy
-            testConfig.strategyArgs
-        );
-
-        (,,,,,,, address strategy) = subject().pools(poolId);
-        assertEq(strategy, subject().DEFAULT_STRATEGY());
-    }
-
     function test_revert_createPool_invalid_priority_fee() public {
         bytes[] memory data = new bytes[](1);
 
@@ -101,7 +80,7 @@ contract TestPortfolioCreatePool is Setup {
                 1, // fee
                 testConfig.priorityFeeBasisPoints.safeCastTo16(), // prior fee
                 address(this), // controller
-                subject().DEFAULT_STRATEGY(),
+                normalStrategy(),
                 testConfig.strategyArgs
             )
         );
@@ -184,7 +163,7 @@ contract TestPortfolioCreatePool is Setup {
                 100,
                 1,
                 address(0),
-                subject().DEFAULT_STRATEGY(),
+                normalStrategy(),
                 abi.encode(
                     PortfolioConfig(
                         100,

--- a/test/TestPositionRendererUri.t.sol
+++ b/test/TestPositionRendererUri.t.sol
@@ -31,7 +31,7 @@ contract TestPositionRendererUri is Setup {
         }
 
         (bytes memory strategyData, uint256 initialX, uint256 initialY) =
-        INormalStrategy(subject().DEFAULT_STRATEGY()).getStrategyData(
+        INormalStrategy(normalStrategy()).getStrategyData(
             ctx.strikePriceWad,
             1_00, // volatilityBasisPoints
             ctx.durationSeconds,
@@ -83,7 +83,7 @@ contract TestPositionRendererUri is Setup {
             isPerpetual: false,
             priceWad: AssemblyLib.scaleToWad(1666 * 10 ** 6, 6),
             controller: address(0),
-            strategy: address(0),
+            strategy: normalStrategy(),
             prioritySwapFee: 0
         });
 
@@ -102,7 +102,7 @@ contract TestPositionRendererUri is Setup {
             isPerpetual: false,
             priceWad: AssemblyLib.scaleToWad(1666 * 10 ** 6, 6),
             controller: address(this),
-            strategy: address(0),
+            strategy: normalStrategy(),
             prioritySwapFee: 200
         });
 
@@ -121,7 +121,7 @@ contract TestPositionRendererUri is Setup {
             isPerpetual: true,
             priceWad: AssemblyLib.scaleToWad(1666 * 10 ** 6, 6),
             controller: address(0),
-            strategy: address(0),
+            strategy: normalStrategy(),
             prioritySwapFee: 0
         });
 
@@ -178,7 +178,7 @@ contract TestPositionRendererUri is Setup {
             isPerpetual: false,
             priceWad: AssemblyLib.scaleToWad(1666 * 10 ** 6, 6),
             controller: address(0),
-            strategy: address(0),
+            strategy: normalStrategy(),
             prioritySwapFee: 0
         });
 


### PR DESCRIPTION
# Changelog
- Removes DEFAULT_STRATEGY state variable in Portfolio contract.
- Removes using the default strategy if a zero address is passed as a strategy in `createPool`.
- Updates the test setup to deploy a normal strategy contract and use it when configuring the portfolio deployment + pools for unit tests.
- Removes using the non-default/default variables in the Position renderer
- Pool id encoded the default/non-default strategy info, so we need to decide on how to replace that info with something useful or remove it. For now, it's defaulting to "false", which is a leading 0x0 bit.